### PR TITLE
Bugfix in CenterCrop. Now works with masks

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -72,7 +72,7 @@ def center_crop(img, crop_height, crop_width):
     y2 = y1 + crop_height
     x1 = (width - crop_width) // 2
     x2 = x1 + crop_width
-    img = img[y1:y2, x1:x2, :]
+    img = img[y1:y2, x1:x2]
     return img
 
 


### PR DESCRIPTION
Now also works with masks of the shape (N, M) and not just (N, M, C)