### PR TITLE
Use uint8 inputs in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ def strong_aug(p=.5):
         HueSaturationValue(p=0.3),
     ], p=p)
 
-image = np.ones((300, 300))
-mask = np.ones((300, 300))
+image = np.ones((300, 300, 3), dtype=np.uint8)
+mask = np.ones((300, 300), dtype=np.uint8)
 whatever_data = "my name"
 augmentation = strong_aug(p=0.9)
 data = {"image": image, "mask": mask, "whatever_data": whatever_data, "additional": "hello"}

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -44,8 +44,8 @@ Examples
            HueSaturationValue(p=0.3),
        ], p=p)
 
-   image = np.ones((300, 300))
-   mask = np.ones((300, 300))
+   image = np.ones((300, 300, 3), dtype=np.uint8)
+   mask = np.ones((300, 300), dtype=np.uint8)
    whatever_data = "my name"
    augmentation = strong_aug(p=0.9)
    data = {"image": image, "mask": mask, "whatever_data": whatever_data, "additional": "hello"}


### PR DESCRIPTION
Use uint8 inputs in the example, because for now some augmentations seem to have problem with float inputs - [Issue #29]