### PR TITLE
Apparently, when computing sum of squares we get a very small number …

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -328,7 +328,7 @@ def optical_distortion(img, k=0, dx=0, dy=0, interpolation=cv2.INTER_LINEAR, bor
     x = x.astype(np.float32) - width / 2 - dx
     y = y.astype(np.float32) - height / 2 - dy
     theta = np.arctan2(y, x)
-    d = (x * x + y * y) ** 0.5
+    d = (x * x + y * y + 1e-8) ** 0.5
     r = d * (1 + k * d * d)
     map_x = r * np.cos(theta) + width / 2 + dx
     map_y = r * np.sin(theta) + height / 2 + dy


### PR DESCRIPTION
Apparently, when computing sum of squares we get a very small number that in occasion cases triggers a runtime warning "RuntimeWarning: invalid value encountered in sqrt".
This commit adds tiny positive number to ensure a sum will be positive.

```
tests/test_transforms.py::test_optical_distortion_interpolation[0]
  D:\Develop\Kaggle\albumentations\albumentations\augmentations\functional.py:335: RuntimeWarning: invalid value encountered in sqrt
    d = (x * x + y * y) ** 0.5
tests/test_transforms.py::test_optical_distortion_interpolation[1]
  D:\Develop\Kaggle\albumentations\albumentations\augmentations\functional.py:335: RuntimeWarning: invalid value encountered in sqrt
    d = (x * x + y * y) ** 0.5
tests/test_transforms.py::test_optical_distortion_interpolation[2]
  D:\Develop\Kaggle\albumentations\albumentations\augmentations\functional.py:335: RuntimeWarning: invalid value encountered in sqrt
    d = (x * x + y * y) ** 0.5
```