### PR TITLE
Proposal/add dependent targets

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -49,7 +49,7 @@ class BasicTransform(object):
             res = {}
             for key, arg in kwargs.items():
                 target_function = self.targets.get(key, lambda x, **p: x)
-                target_dependencies = {k: kwargs[k] for k in self.target_dependence[key]}
+                target_dependencies = {k: kwargs[k] for k in self.target_dependence.get(key, [])}
                 res[key] = target_function(arg, **dict(params, **target_dependencies))
             return res
         return kwargs

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -46,7 +46,12 @@ class BasicTransform(object):
         if random.random() < self.p:
             params = self.get_params()
             params = self.update_params(params, **kwargs)
-            return {key: self.targets.get(key, lambda x, **p: x)(arg, **params) for key, arg in kwargs.items()}
+            res = {}
+            for key, arg in kwargs.items():
+                target_function = self.targets.get(key, lambda x, **p: x)
+                target_dependencies = {k: kwargs[k] for k in self.target_dependence[key]}
+                res[key] = target_function(arg, **dict(params, **target_dependencies))
+            return res
         return kwargs
 
     def apply(self, img, **params):
@@ -67,6 +72,10 @@ class BasicTransform(object):
             params['interpolation'] = self.interpolation
         params.update({'cols': kwargs['image'].shape[1], 'rows': kwargs['image'].shape[0]})
         return params
+
+    @property
+    def target_dependence(self):
+        return {}
 
 
 class DualTransform(BasicTransform):


### PR DESCRIPTION
add ability to make targets dependent on other targets.  …
it could be useful if you want to augment bboxes and labels
in the same place, but store bboxes and labels in different targets.