### PR TITLE
Fix mask interpolation. Bug occured in transfomation classes which di…

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'
 
 from .core.composition import *
 from .core.transforms_interface import *

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -409,7 +409,7 @@ def elastic_transform_fast(image, alpha, sigma, alpha_affine, interpolation=cv2.
     pts2 = pts1 + random_state.uniform(-alpha_affine, alpha_affine, size=pts1.shape).astype(np.float32)
     matrix = cv2.getAffineTransform(pts1, pts2)
 
-    image = cv2.warpAffine(image, matrix, (width, height), borderMode=border_mode)
+    image = cv2.warpAffine(image, matrix, (width, height), flags=interpolation, borderMode=border_mode)
 
     dx = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
     dy = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -181,7 +181,6 @@ class LongestMaxSize(DualTransform):
     def apply(self, img, interpolation=cv2.INTER_LINEAR, **params):
         return F.longest_max_size(img, longest_max_size=self.max_size, interpolation=interpolation)
 
-
     def apply_to_bbox(self, bbox, **params):
         # Bounding box coordinates are scale invariant
         return bbox
@@ -451,7 +450,7 @@ class RandomSizedCrop(DualTransform):
         self.min_max_height = min_max_height
         self.w2h_ratio = w2h_ratio
 
-    def apply(self, img, crop_height=0, crop_width=0, h_start=0, w_start=0, interpolation=cv2.INTER_LINEAR,  **params):
+    def apply(self, img, crop_height=0, crop_width=0, h_start=0, w_start=0, interpolation=cv2.INTER_LINEAR, **params):
         crop = F.random_crop(img, crop_height, crop_width, h_start, w_start)
         return F.resize(crop, self.height, self.width, interpolation)
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -178,8 +178,9 @@ class LongestMaxSize(DualTransform):
         self.interpolation = interpolation
         self.max_size = max_size
 
-    def apply(self, img, **params):
-        return F.longest_max_size(img, longest_max_size=self.max_size, interpolation=self.interpolation)
+    def apply(self, img, interpolation=cv2.INTER_LINEAR, **params):
+        return F.longest_max_size(img, longest_max_size=self.max_size, interpolation=interpolation)
+
 
     def apply_to_bbox(self, bbox, **params):
         # Bounding box coordinates are scale invariant
@@ -450,9 +451,9 @@ class RandomSizedCrop(DualTransform):
         self.min_max_height = min_max_height
         self.w2h_ratio = w2h_ratio
 
-    def apply(self, img, crop_height=0, crop_width=0, h_start=0, w_start=0, **params):
+    def apply(self, img, crop_height=0, crop_width=0, h_start=0, w_start=0, interpolation=cv2.INTER_LINEAR,  **params):
         crop = F.random_crop(img, crop_height, crop_width, h_start, w_start)
-        return F.resize(crop, self.height, self.width, self.interpolation)
+        return F.resize(crop, self.height, self.width, interpolation)
 
     def get_params(self):
         crop_height = random.randint(self.min_max_height[0], self.min_max_height[1])

--- a/albumentations/imgaug/transforms.py
+++ b/albumentations/imgaug/transforms.py
@@ -29,14 +29,15 @@ class DualIAATransform(DualTransform, BasicIAATransform):
         super(DualIAATransform, self).__init__(p)
 
     def apply_to_bboxes(self, bboxes, rows=0, cols=0, **params):
-        bboxes = convert_bboxes_from_albumentations((rows, cols), bboxes, 'pascal_voc')
+        if len(bboxes):
+            bboxes = convert_bboxes_from_albumentations((rows, cols), bboxes, 'pascal_voc')
 
-        bboxes_t = ia.BoundingBoxesOnImage([ia.BoundingBox(*bbox[:4]) for bbox in bboxes], (rows, cols))
-        bboxes_t = self.deterministic_processor.augment_bounding_boxes([bboxes_t])[0].bounding_boxes
-        bboxes_t = [[bbox.x1, bbox.y1, bbox.x2, bbox.y2] + list(bbox_orig[4:]) for (bbox, bbox_orig) in
-                    zip(bboxes_t, bboxes)]
+            bboxes_t = ia.BoundingBoxesOnImage([ia.BoundingBox(*bbox[:4]) for bbox in bboxes], (rows, cols))
+            bboxes_t = self.deterministic_processor.augment_bounding_boxes([bboxes_t])[0].bounding_boxes
+            bboxes_t = [[bbox.x1, bbox.y1, bbox.x2, bbox.y2] + list(bbox_orig[4:]) for (bbox, bbox_orig) in
+                        zip(bboxes_t, bboxes)]
 
-        bboxes = convert_bboxes_to_albumentations((rows, cols), bboxes_t, 'pascal_voc')
+            bboxes = convert_bboxes_to_albumentations((rows, cols), bboxes_t, 'pascal_voc')
         return bboxes
 
 
@@ -139,6 +140,8 @@ class IAAPiecewiseAffine(DualIAATransform):
     """Place a regular grid of points on the input and randomly move the neighbourhood of these point around
     via affine transformations.
 
+    Note: This class introduce interpolation artifacts to mask if it has values other than {0;1}
+
     Args:
         scale ((float, float): factor range that determines how far each point is moved. Default: (0.03, 0.05).
         nb_rows (int): number of rows of points that the regular grid should have. Default: 4.
@@ -158,6 +161,8 @@ class IAAAffine(DualIAATransform):
     """Place a regular grid of points on the input and randomly move the neighbourhood of these point around
     via affine transformations.
 
+    Note: This class introduce interpolation artifacts to mask if it has values other than {0;1}
+
     Args:
         p (float): probability of applying the transform. Default: 0.5.
 
@@ -173,6 +178,8 @@ class IAAAffine(DualIAATransform):
 
 class IAAPerspective(DualIAATransform):
     """Perform a random four point perspective transform of the input.
+
+    Note: This class introduce interpolation artifacts to mask if it has values other than {0;1}
 
     Args:
         scale ((float, float): standard deviation of the normal distributions. These are used to sample

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2,8 +2,9 @@ import numpy as np
 import cv2
 import pytest
 
-from albumentations import Transpose, Rotate, ShiftScaleRotate, OpticalDistortion, GridDistortion, ElasticTransform,\
-    VerticalFlip, HorizontalFlip
+from albumentations import Transpose, Rotate, ShiftScaleRotate, OpticalDistortion, GridDistortion, ElasticTransform, \
+    VerticalFlip, HorizontalFlip, RandomSizedCrop, RandomScale, IAAPiecewiseAffine, IAAAffine, IAAPerspective, \
+    LongestMaxSize
 import albumentations.augmentations.functional as F
 
 
@@ -88,3 +89,32 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
                                              random_state=np.random.RandomState(1111))
     assert np.array_equal(data['image'], expected_image)
     assert np.array_equal(data['mask'], expected_mask)
+
+
+@pytest.mark.parametrize('transformation', [ElasticTransform(), GridDistortion(), ShiftScaleRotate(rotate_limit=45),
+                                            RandomScale(scale_limit=0.5), RandomSizedCrop((80, 90), 100, 100),
+                                            IAAAffine(scale=1.5), IAAPiecewiseAffine(scale=1.5), IAAPerspective(),
+                                            LongestMaxSize(50), Rotate()])
+def test_binary_mask_interpolation(transformation):
+    """ Checks whether transformations based on DualTransform does not introduce a mask interpolation artifacts"""
+    transformation.p = 1
+    image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
+    mask = np.random.randint(low=0, high=2, size=(100, 100), dtype=np.uint8)
+
+    data = transformation(image=image, mask=mask)
+    assert np.array_equal(np.unique(data['mask']), np.array([0, 1]))
+
+
+@pytest.mark.parametrize('transformation', [ElasticTransform(), GridDistortion(), ShiftScaleRotate(rotate_limit=45),
+                                            RandomScale(scale_limit=0.5), RandomSizedCrop((80, 90), 100, 100),
+                                            LongestMaxSize(50), Rotate()])
+def test_semantic_mask_interpolation(transformation):
+    """ Checks whether transformations based on DualTransform does not introduce a mask interpolation artifacts.
+    Note: IAAAffine, IAAPiecewiseAffine, IAAPerspective does not properly operate if mask has values other than {0;1}
+    """
+    transformation.p = 1
+    image = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
+    mask = np.random.randint(low=0, high=4, size=(100, 100), dtype=np.uint8) * 64
+
+    data = transformation(image=image, mask=mask)
+    assert np.array_equal(np.unique(data['mask']), np.array([0, 64, 128, 192]))


### PR DESCRIPTION
Fix mask interpolation in LongestMaxSize, RandomSizedCrop, ElasticTransform. Bug occured in transformation classes which did not have named parameter 'interpolation' in apply().
Also discovered that IAA-based transformations IAAAffine, IAAPiecewiseAffine, IAAPerspective does not properly handle mask with values other than {0,1}.
