### PR TITLE
Replace cv2.flip(hflip+vflip) to numpy flip (performance reason)

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -19,11 +19,11 @@ MAX_VALUES_BY_DTYPE = {
 
 
 def vflip(img):
-    return cv2.flip(img, 0)
+    return np.ascontiguousarray(img[::-1,...])
 
 
 def hflip(img):
-    return cv2.flip(img, 1)
+    return np.ascontiguousarray(img[:,::-1,...])
 
 
 def random_flip(img, code):


### PR DESCRIPTION
numpy img[::-1,:,...] is faster then cv2.flip(arr, 0) 
and same for img[:,::-1,...] with cv2.flip(arr, 1) 