### PR TITLE
Update functional.normalize

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -84,8 +84,9 @@ def rot90(img, factor):
 def normalize(img, mean, std, max_pixel_value=255.0):
     img = img.astype(np.float32) / max_pixel_value
 
-    img -= np.ones(img.shape) * mean
-    img /= np.ones(img.shape) * std
+    img = cv2.subtract(img, np.ones_like(img) * np.asarray(mean, dtype=np.float32))
+    img = cv2.divide(img, np.ones_like(img) * np.asarray(std, dtype=np.float32))
+
     return img
 
 


### PR DESCRIPTION
Array normalisation seems to be a surprisingly slow process. Using OpenCV instead of NumPy operations it's 30% faster.

Note that the proposed `normalize()` function does not return the same exact array. but the mean absolute difference is of the order of 5e-8

~~~~~~~~~~
Timings for the operation on an image of shape (1024, 1224, 3):
- OLD: 37.6 ms ± 767 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
- NEW: 22.4 ms ± 103 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)