### PR TITLE
add params dependent on targets

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -25,6 +25,10 @@ class BasicTransform(object):
         if (random.random() < self.p) or self.always_apply:
             params = self.get_params()
             params = self.update_params(params, **kwargs)
+            if self.targets_as_params:
+                targets_as_params = {k: kwargs[k] for k in self.targets_as_params}
+                params_dependent_on_targets = self.get_params_dependent_on_targets(targets_as_params)
+                params.update(params_dependent_on_targets)
             res = {}
             for key, arg in kwargs.items():
                 if arg is not None:
@@ -58,6 +62,13 @@ class BasicTransform(object):
     @property
     def target_dependence(self):
         return {}
+
+    @property
+    def targets_as_params(self):
+        return []
+
+    def get_params_dependent_on_targets(self, params):
+        raise NotImplementedError
 
 
 class DualTransform(BasicTransform):


### PR DESCRIPTION
Sometimes you want params being dependent on targets.
Example usecase:
Crop images randomly around single box in image. You need to pass this box to params to generate random positions for crop.