### PR TITLE
More efficient normalization op. 

### DIFF
--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 
 from .core.composition import *
 from .core.transforms_interface import *

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -82,11 +82,17 @@ def rot90(img, factor):
 
 
 def normalize(img, mean, std, max_pixel_value=255.0):
-    img = img.astype(np.float32) / max_pixel_value
+    mean = np.array(mean, dtype=np.float32)
+    mean *= max_pixel_value
 
-    img = cv2.subtract(img, np.ones_like(img) * np.asarray(mean, dtype=np.float32))
-    img = cv2.divide(img, np.ones_like(img) * np.asarray(std, dtype=np.float32))
+    std = np.array(std, dtype=np.float32)
+    std *= max_pixel_value
 
+    denominator = np.reciprocal(std, dtype=np.float32)
+
+    img = img.astype(np.float32)
+    img -= mean
+    img *= denominator
     return img
 
 


### PR DESCRIPTION
On 512x512x4 image it's ~3X times faster than previous implementation.

512x512x4
```
name           calls time(ms)
normalize_old  100   3000
normalize_fast 100   752
```

256x256x3
```
name           calls time(ms)
normalize_old  100   435
normalize_fast 100   133
```