### PR TITLE
Fix Travis CI builds for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+env:
+  - IMGAUG_NO_CV2_INSTALLED_CHECK=TRUE
+
 matrix:
   include:
     - python: 2.7


### PR DESCRIPTION
Add a special environment variable to prevent ImgAug from checking OpenCV during installation.