### PR TITLE
Fixes empty pytorch transforms docs

### DIFF
--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -38,12 +38,13 @@ def mask_to_tensor(mask, num_classes, sigmoid):
 
 
 class ToTensor(BasicTransform):
-    """Convert image to `torch.Tensor`
+    """Convert image and mask to `torch.Tensor` and divide by 255 if image or mask are `uint8` type.
+    WARNING! Please use this with care and look into sources before usage.
 
     Args:
-        num_classes (int):
-        sigmoid (bool, optional):
-        normalize (optional): If True, normalizes image tensor with mean and standard deviation
+        num_classes (int): only for segmentation
+        sigmoid (bool, optional): only for segmentation, transform mask to LongTensor or not.
+        normalize (dict, optional): dict with keys [mean, std] to pass it into torchvision.normalize
 
     """
 

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -38,6 +38,14 @@ def mask_to_tensor(mask, num_classes, sigmoid):
 
 
 class ToTensor(BasicTransform):
+    """Convert image to `torch.Tensor`
+
+    Args:
+        num_classes (int):
+        sigmoid (bool, optional):
+        normalize (optional):
+    
+    """
     def __init__(self, num_classes=1, sigmoid=True, normalize=None):
         super(ToTensor, self).__init__(always_apply=True, p=1.)
         self.num_classes = num_classes

--- a/albumentations/pytorch/transforms.py
+++ b/albumentations/pytorch/transforms.py
@@ -43,9 +43,10 @@ class ToTensor(BasicTransform):
     Args:
         num_classes (int):
         sigmoid (bool, optional):
-        normalize (optional):
-    
+        normalize (optional): If True, normalizes image tensor with mean and standard deviation
+
     """
+
     def __init__(self, num_classes=1, sigmoid=True, normalize=None):
         super(ToTensor, self).__init__(always_apply=True, p=1.)
         self.num_classes = num_classes

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,4 +7,4 @@ API
    ./core
    ./augmentations
    ./imgaug
-   ./torch
+   ./pytorch

--- a/docs/api/pytorch.rst
+++ b/docs/api/pytorch.rst
@@ -1,0 +1,7 @@
+PyTorch helpers (albumentations.pytorch)
+======================================
+
+Transforms
+----------
+.. automodule:: albumentations.pytorch.transforms
+    :members:

--- a/docs/api/torch.rst
+++ b/docs/api/torch.rst
@@ -1,7 +1,0 @@
-PyTorch helpers (albumentations.torch)
-======================================
-
-Transforms
-----------
-.. automodule:: albumentations.torch.transforms
-    :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-autobuild
 sphinx_rtd_theme
 mock
 scikit-image
+https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl


### PR DESCRIPTION
This PR should fix the problem of empty API/Torch page: https://albumentations.readthedocs.io/en/latest/api/torch.html

- `torch` -> `pytorch`
- installs pytorch cpu py35 from requirements.txt
- added a tiny doc

All can looks like this : https://vfdev-5-albumentations.readthedocs.io/en/docs_pytorch_fix/api/pytorch.html#module-albumentations.pytorch.transforms
