### PR TITLE
Add approximate parameter for faster elastic transform

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -455,8 +455,8 @@ def grid_distortion(img, num_steps=10, xsteps=[], ysteps=[], interpolation=cv2.I
 
 
 @preserve_shape
-def elastic_transform_fast(image, alpha, sigma, alpha_affine, interpolation=cv2.INTER_LINEAR,
-                           border_mode=cv2.BORDER_REFLECT_101, random_state=None):
+def elastic_transform(image, alpha, sigma, alpha_affine, interpolation=cv2.INTER_LINEAR,
+                      border_mode=cv2.BORDER_REFLECT_101, random_state=None, approximate=False):
     """Elastic deformation of images as described in [Simard2003]_ (with modifications).
     Based on https://gist.github.com/erniejunior/601cdf56d2b424757de5
 
@@ -484,8 +484,65 @@ def elastic_transform_fast(image, alpha, sigma, alpha_affine, interpolation=cv2.
 
     image = cv2.warpAffine(image, matrix, (width, height), flags=interpolation, borderMode=border_mode)
 
-    dx = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
-    dy = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
+    if approximate:
+        # Approximate computation smooth displacement map with a large enough kernel.
+        # On large images (512+) this is approximately 2X times faster
+        dx = (random_state.rand(height, width).astype(np.float32) * 2 - 1)
+        cv2.GaussianBlur(dx, (17, 17), sigma, dst=dx)
+        dx *= alpha
+
+        dy = (random_state.rand(height, width).astype(np.float32) * 2 - 1)
+        cv2.GaussianBlur(dy, (17, 17), sigma, dst=dy)
+        dy *= alpha
+    else:
+        dx = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
+        dy = np.float32(gaussian_filter((random_state.rand(height, width) * 2 - 1), sigma) * alpha)
+
+    x, y = np.meshgrid(np.arange(width), np.arange(height))
+
+    mapx = np.float32(x + dx)
+    mapy = np.float32(y + dy)
+
+    return cv2.remap(image, mapx, mapy, interpolation, borderMode=border_mode)
+
+
+@preserve_shape
+def elastic_transform_approx(image, alpha, sigma, alpha_affine, interpolation=cv2.INTER_LINEAR,
+                             border_mode=cv2.BORDER_REFLECT_101, random_state=None):
+    """Elastic deformation of images as described in [Simard2003]_ (with modifications for speed).
+    Based on https://gist.github.com/erniejunior/601cdf56d2b424757de5
+
+    .. [Simard2003] Simard, Steinkraus and Platt, "Best Practices for
+         Convolutional Neural Networks applied to Visual Document Analysis", in
+         Proc. of the International Conference on Document Analysis and
+         Recognition, 2003.
+    """
+    if random_state is None:
+        random_state = np.random.RandomState(1234)
+
+    height, width = image.shape[:2]
+
+    # Random affine
+    center_square = np.float32((height, width)) // 2
+    square_size = min((height, width)) // 3
+    alpha = float(alpha)
+    sigma = float(sigma)
+    alpha_affine = float(alpha_affine)
+
+    pts1 = np.float32([center_square + square_size, [center_square[0] + square_size, center_square[1] - square_size],
+                       center_square - square_size])
+    pts2 = pts1 + random_state.uniform(-alpha_affine, alpha_affine, size=pts1.shape).astype(np.float32)
+    matrix = cv2.getAffineTransform(pts1, pts2)
+
+    image = cv2.warpAffine(image, matrix, (width, height), flags=interpolation, borderMode=border_mode)
+
+    dx = (random_state.rand(height, width).astype(np.float32) * 2 - 1)
+    cv2.GaussianBlur(dx, (17, 17), sigma, dst=dx)
+    dx *= alpha
+
+    dy = (random_state.rand(height, width).astype(np.float32) * 2 - 1)
+    cv2.GaussianBlur(dy, (17, 17), sigma, dst=dy)
+    dy *= alpha
 
     x, y = np.meshgrid(np.arange(width), np.arange(height))
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -710,7 +710,18 @@ class GridDistortion(DualTransform):
 
 
 class ElasticTransform(DualTransform):
-    """
+    """Elastic deformation of images as described in [Simard2003]_ (with modifications).
+    Based on https://gist.github.com/erniejunior/601cdf56d2b424757de5
+
+    .. [Simard2003] Simard, Steinkraus and Platt, "Best Practices for
+         Convolutional Neural Networks applied to Visual Document Analysis", in
+         Proc. of the International Conference on Document Analysis and
+         Recognition, 2003.
+
+    Args:
+        approximate (boolean): Whether to smooth displacement map with fixed kernel size.
+                               Enabling this option gives ~2X speedup on large images.
+
     Targets:
         image, mask
 
@@ -719,17 +730,19 @@ class ElasticTransform(DualTransform):
     """
 
     def __init__(self, alpha=1, sigma=50, alpha_affine=50, interpolation=cv2.INTER_LINEAR,
-                 border_mode=cv2.BORDER_REFLECT_101, always_apply=False, p=0.5):
+                 border_mode=cv2.BORDER_REFLECT_101, always_apply=False, approximate=False, p=0.5):
         super(ElasticTransform, self).__init__(always_apply, p)
         self.alpha = alpha
         self.alpha_affine = alpha_affine
         self.sigma = sigma
         self.interpolation = interpolation
         self.border_mode = border_mode
+        self.approximate = approximate
 
     def apply(self, img, random_state=None, interpolation=cv2.INTER_LINEAR, **params):
-        return F.elastic_transform_fast(img, self.alpha, self.sigma, self.alpha_affine, interpolation,
-                                        self.border_mode, np.random.RandomState(random_state))
+        return F.elastic_transform(img, self.alpha, self.sigma, self.alpha_affine, interpolation,
+                                   self.border_mode, np.random.RandomState(random_state),
+                                   self.approximate)
 
     def get_params(self):
         return {'random_state': random.randint(0, 10000)}

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -83,13 +83,13 @@ def test_elastic_transform_interpolation(monkeypatch, interpolation):
                         lambda *_: {'random_state': 1111})
     aug = ElasticTransform(alpha=1, sigma=50, alpha_affine=50, interpolation=interpolation, p=1)
     data = aug(image=image, mask=mask)
-    expected_image = F.elastic_transform_fast(image, alpha=1, sigma=50, alpha_affine=50, interpolation=interpolation,
-                                              border_mode=cv2.BORDER_REFLECT_101,
-                                              random_state=np.random.RandomState(1111))
-    expected_mask = F.elastic_transform_fast(mask, alpha=1, sigma=50, alpha_affine=50,
-                                             interpolation=cv2.INTER_NEAREST,
-                                             border_mode=cv2.BORDER_REFLECT_101,
-                                             random_state=np.random.RandomState(1111))
+    expected_image = F.elastic_transform(image, alpha=1, sigma=50, alpha_affine=50, interpolation=interpolation,
+                                         border_mode=cv2.BORDER_REFLECT_101,
+                                         random_state=np.random.RandomState(1111))
+    expected_mask = F.elastic_transform(mask, alpha=1, sigma=50, alpha_affine=50,
+                                        interpolation=cv2.INTER_NEAREST,
+                                        border_mode=cv2.BORDER_REFLECT_101,
+                                        random_state=np.random.RandomState(1111))
     assert np.array_equal(data['image'], expected_image)
     assert np.array_equal(data['mask'], expected_mask)
 


### PR DESCRIPTION
Nothing special, just a 2X speedup on 512+ patches at price of slightly different distorted image (visually hard to notice).