### PR TITLE
Add `fit_output` parameter for IAAAffine

### DIFF
--- a/albumentations/imgaug/transforms.py
+++ b/albumentations/imgaug/transforms.py
@@ -235,7 +235,7 @@ class IAAAffine(DualIAATransform):
     """
 
     def __init__(self, scale=1.0, translate_percent=None, translate_px=None, rotate=0.0, shear=0.0, order=1, cval=0,
-                 mode='reflect', always_apply=False, p=0.5):
+                 mode='reflect', always_apply=False, p=0.5, fit_output=False):
         super(IAAAffine, self).__init__(always_apply, p)
         self.scale = to_tuple(scale, 1.0)
         self.translate_percent = to_tuple(translate_percent, 0)
@@ -245,11 +245,12 @@ class IAAAffine(DualIAATransform):
         self.order = order
         self.cval = cval
         self.mode = mode
+        self.fit_output = fit_output
 
     @property
     def processor(self):
         return iaa.Affine(self.scale, self.translate_percent, self.translate_px, self.rotate, self.shear,
-                          self.order, self.cval, self.mode)
+                          self.order, self.cval, self.mode, fit_output=self.fit_output)
 
 
 class IAAPerspective(DualIAATransform):


### PR DESCRIPTION
Hi, when using IAAAffine, there is no way to keep the image after affine transformation to completely contained in the output. A lot of people use this frequently so it is very annoying

Affine Transform in `imgaug` supported this use case, we just need to pass `fit_output=True` when init it, but we can't do that via albumentations.

So I made a small Pull Request to resolve this problem (#194 issue). Can you guys consider to merge it ?

Thanks ❤️