### PR TITLE
Fix in torchvision2albumentations notebook

### DIFF
--- a/notebooks/migrating_from_torchvision_to_albumentations.ipynb
+++ b/notebooks/migrating_from_torchvision_to_albumentations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class AlbumentationsPilDataset(Dataset):\n",
@@ -220,9 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/notebooks/migrating_from_torchvision_to_albumentations.ipynb
+++ b/notebooks/migrating_from_torchvision_to_albumentations.ipynb
@@ -103,7 +103,7 @@
     "        if self.transform:\n",
     "            augmented = self.transform(image=image)\n",
     "            image = augmented['image']\n",
-    "        return img_to_tensor(image), label\n",
+    "        return image, label\n",
     "\n",
     "\n",
     "albumentations_transform = Compose([\n",

--- a/notebooks/migrating_from_torchvision_to_albumentations.ipynb
+++ b/notebooks/migrating_from_torchvision_to_albumentations.ipynb
@@ -2,10 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from PIL import Image\n",
@@ -14,7 +12,7 @@
     "from torch.utils.data import Dataset\n",
     "from torchvision import transforms\n",
     "from albumentations import Compose, RandomCrop, Normalize, HorizontalFlip, Resize\n",
-    "from albumentations.pytorch.functional import img_to_tensor"
+    "from albumentations.pytorch import ToTensor"
    ]
   },
   {
@@ -26,10 +24,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TorchvisionDataset(Dataset):\n",
@@ -80,10 +76,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
     "class AlbumentationsDataset(Dataset):\n",
@@ -119,7 +113,8 @@
     "    Normalize(\n",
     "        mean=[0.485, 0.456, 0.406],\n",
     "        std=[0.229, 0.224, 0.225],\n",
-    "    )\n",
+    "    ),\n",
+    "    ToTensor()\n",
     "])\n",
     "\n",
     "\n",
@@ -248,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/migrating_from_torchvision_to_albumentations.ipynb
+++ b/notebooks/migrating_from_torchvision_to_albumentations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -72,28 +72,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 (torch.Size([1, 3, 224, 224]), tensor([3]))\n",
-      "1 (torch.Size([1, 3, 224, 224]), tensor([1]))\n",
-      "2 (torch.Size([1, 3, 224, 224]), tensor([2]))\n"
-     ]
-    }
-   ],
-   "source": [
-    "from torch.utils.data import DataLoader\n",
-    "trainloader = DataLoader(torchvision_dataset, batch_size=1,shuffle=True, num_workers=1)\n",
-    "for i, (image, label) in enumerate(trainloader):\n",
-    "    print(i, (image.shape, label))"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },

--- a/notebooks/migrating_from_torchvision_to_albumentations.ipynb
+++ b/notebooks/migrating_from_torchvision_to_albumentations.ipynb
@@ -2,8 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from PIL import Image\n",
@@ -11,7 +13,8 @@
     "import numpy as np\n",
     "from torch.utils.data import Dataset\n",
     "from torchvision import transforms\n",
-    "from albumentations import Compose, RandomCrop, Normalize, HorizontalFlip, Resize"
+    "from albumentations import Compose, RandomCrop, Normalize, HorizontalFlip, Resize\n",
+    "from albumentations.pytorch.functional import img_to_tensor"
    ]
   },
   {
@@ -23,8 +26,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class TorchvisionDataset(Dataset):\n",
@@ -67,6 +72,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 (torch.Size([1, 3, 224, 224]), tensor([3]))\n",
+      "1 (torch.Size([1, 3, 224, 224]), tensor([1]))\n",
+      "2 (torch.Size([1, 3, 224, 224]), tensor([2]))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "trainloader = DataLoader(torchvision_dataset, batch_size=1,shuffle=True, num_workers=1)\n",
+    "for i, (image, label) in enumerate(trainloader):\n",
+    "    print(i, (image.shape, label))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -75,8 +102,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class AlbumentationsDataset(Dataset):\n",
@@ -102,7 +131,7 @@
     "        if self.transform:\n",
     "            augmented = self.transform(image=image)\n",
     "            image = augmented['image']\n",
-    "        return image, label\n",
+    "        return img_to_tensor(image), label\n",
     "\n",
     "\n",
     "albumentations_transform = Compose([\n",
@@ -139,8 +168,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class AlbumentationsPilDataset(Dataset):\n",
@@ -212,6 +243,15 @@
     "| [Resize](https://pytorch.org/docs/stable/torchvision/transforms.html#torchvision.transforms.Resize) \t| [Resize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Resize) \t| ```Resize(256, 256)``` \t|\n",
     "| [Normalize](https://pytorch.org/docs/stable/torchvision/transforms.html#torchvision.transforms.Normalize) \t| [Normalize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Normalize) \t| ```Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])``` \t|"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -230,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added img_to_tensor operation to make albumentations DataLoader directly used in PyTorch.