### PR TITLE
Faster hflip with OpenCV

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -66,6 +66,10 @@ def hflip(img):
     return np.ascontiguousarray(img[:, ::-1, ...])
 
 
+def hflip_cv2(img):
+    return cv2.flip(img, 1)
+
+
 @preserve_shape
 def random_flip(img, code):
     return cv2.flip(img, code)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -149,7 +149,9 @@ class HorizontalFlip(DualTransform):
     """
 
     def apply(self, img, **params):
-        if img.ndim == 3 and img.shape[2] > 1:
+        if img.ndim == 3 and img.shape[2] > 1 and img.dtype == np.uint8:
+            # Opencv is faster than numpy only in case of
+            # non-gray scale 8bits images
             return F.hflip_cv2(img)
         else:
             return F.hflip(img)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -149,7 +149,10 @@ class HorizontalFlip(DualTransform):
     """
 
     def apply(self, img, **params):
-        return F.hflip(img)
+        if img.ndim == 3 and img.shape[2] > 1:
+            return F.hflip_cv2(img)
+        else:
+            return F.hflip(img)
 
     def apply_to_bbox(self, bbox, **params):
         return F.bbox_hflip(bbox, **params)


### PR DESCRIPTION
Hi, 
A simple replacement with OpenCV seems to give a ~3x acceration:
- Numpy: '1.16.1'
- OpenCV: 4.0.0

```
x.shape = (281, 500, 3)
```
1) current implementation
```python
%%timeit -r 7 -n 10
for _ in range(1000):
    hflip(x)
> 681 ms ± 3.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
2) with opencv
```python
%%timeit -r 7 -n 10
for _ in range(1000):
    hflip_fast(x)
> 197 ms ± 77.8 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
and compare with `vflip`
```python
%%timeit -r 7 -n 10
for _ in range(1000):
    vflip(x)
> 30.3 ms ± 108 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Both `hflip*` implementations give the same result and `C_CONTIGUOUS` arrays:
```python
(hflip(x) == hflip_fast(x)).all()
> True
r1 = hflip(x)
r1.flags['C_CONTIGUOUS']
> True
r2 = hflip_fast(x)
r2.flags['C_CONTIGUOUS']
> True
```

What do you think about such modification ?


**EDIT:**
on `x.shape=(281, 500, 1)` this implementation is slower than the original one:
```python
%%timeit -r 7 -n 10
for _ in range(1000):
    hflip(x)
> 48.5 ms ± 2.64 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%%timeit -r 7 -n 10
for _ in range(1000):
    hflip_fast(x)
> 62.6 ms ± 177 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%%timeit -r 7 -n 10
for _ in range(1000):
    vflip(x)
> 12.6 ms ± 112 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
For other number of channels, e.g. 2, 3, 5, ... opencv seems to be faster but scales in time, however numpy is not.