### PR TITLE
opencv-python-headless should be enough, and easier to deploy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     license='MIT',
     url='https://github.com/albu/albumentations',
     packages=find_packages(exclude=['tests']),
-    install_requires=['numpy>=1.11.1', 'scipy', 'opencv-python', 'imgaug>=0.2.5,<0.2.7'],
+    install_requires=['numpy>=1.11.1', 'scipy', 'opencv-python-headless', 'imgaug>=0.2.5,<0.2.7'],
     extras_require={'tests': get_test_requirements()},
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi,

It looks like nothing, but could really make packager life easier.
As opencv-python imply several extra libs to be installed on system (such as libSM).

Thanks in advance,