### PR TITLE
Fix https://github.com/albu/albumentations/issues/182

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -164,15 +164,20 @@ def shift_scale_rotate(img, angle, scale, dx, dy, interpolation=cv2.INTER_LINEAR
 
 
 def bbox_shift_scale_rotate(bbox, angle, scale, dx, dy, interpolation, rows, cols, **params):
-    center = (0.5, 0.5)
+    height, width = rows, cols
+    center = (width / 2, height / 2)
     matrix = cv2.getRotationMatrix2D(center, angle, scale)
-    matrix[0, 2] += dx
-    matrix[1, 2] += dy
+    matrix[0, 2] += dx * width
+    matrix[1, 2] += dy * height
     x = np.array([bbox[0], bbox[2], bbox[2], bbox[0]])
     y = np.array([bbox[1], bbox[1], bbox[3], bbox[3]])
     ones = np.ones(shape=(len(x)))
     points_ones = np.vstack([x, y, ones]).transpose()
+    points_ones[:, 0] *= width
+    points_ones[:, 1] *= height
     tr_points = matrix.dot(points_ones.T).T
+    tr_points[:, 0] /= width
+    tr_points[:, 1] /= height
     return [min(tr_points[:, 0]), min(tr_points[:, 1]), max(tr_points[:, 0]), max(tr_points[:, 1])]
 
 


### PR DESCRIPTION
This PR fixes bug with ShiftRotateScale when applied for bboxes in case of non-square images. The bug was caused by inconsistent representation of bboxes (normalized coordinates) and image coordinates (pixels) when applying affine transformation. It can be illustrated as shown below:

![Original](https://user-images.githubusercontent.com/532320/55673830-ed980a80-58b5-11e9-8ebc-48c449799370.png)

![Rotated_bug](https://user-images.githubusercontent.com/532320/55673829-ecff7400-58b5-11e9-820f-3d762147906d.png)

After applying suggested in #182 denormalization, it seems to be fixed:

![Rotated_fixed](https://user-images.githubusercontent.com/532320/55673828-ecff7400-58b5-11e9-9aa5-c5493dc3b185.png)
