### PR TITLE
Add to Lambda transform "image only" mode

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from . import functional as F
 from .bbox_utils import union_of_bboxes, denormalize_bbox, normalize_bbox
-from ..core.transforms_interface import to_tuple, DualTransform, ImageOnlyTransform
+from ..core.transforms_interface import to_tuple, DualTransform, ImageOnlyTransform, NoOp
 
 __all__ = ['Blur', 'VerticalFlip', 'HorizontalFlip', 'Flip', 'Normalize', 'Transpose', 'RandomCrop', 'RandomGamma',
            'RandomRotate90', 'Rotate', 'ShiftScaleRotate', 'CenterCrop', 'OpticalDistortion', 'GridDistortion',
@@ -1701,7 +1701,7 @@ class FromFloat(ImageOnlyTransform):
         return F.from_float(img, self.dtype, self.max_value)
 
 
-class Lambda(DualTransform):
+class Lambda(NoOp):
     """A flexible transformation class for using user-defined transformation functions per targets.
     Function signature must include **kwargs to accept optinal arguments like interpolation method, image size, etc:
 


### PR DESCRIPTION
Add ability to apply function only for image.

Previous version fail in such case:
```python
import numpy as np
import albumentations as alb

def preprocess_input(x, **kwargs):
    return x / 255.

transform = alb.Compose([
    alb.Lambda(image=preprocess_input),
])

transform(image=np.ones((32, 32, 3)), mask=np.ones((32, 32, 3)))
```