### PR TITLE
Fix the Lambda transform

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1136,3 +1136,7 @@ def py3round(number):
         return int(2.0 * round(number / 2.0))
 
     return int(round(number))
+
+
+def noop(input_obj, **params):
+    return input_obj


### PR DESCRIPTION
In the current implementation of `Lambda` bbox and keypoint transforms are [added to the `_targets` dict using 'bbox' and 'keypoint'](https://github.com/albu/albumentations/blob/master/albumentations/augmentations/transforms.py#L1904) (in singular forms) keys respectively. However, DualTransform [uses keys 'bboxes' and 'keypoints' ](https://github.com/albu/albumentations/blob/master/albumentations/core/transforms_interface.py#L162-L163)(in plural forms) to find the appropriate transform methods. And because of that Lambda will always use [default implementations](https://github.com/albu/albumentations/blob/master/albumentations/core/transforms_interface.py#L197-L201) of `apply_to_bbox` and `apply_to_keypoint` methods from NoOp.

Here is a possible fix for this problem, but I am not sure, maybe there is a better way. @BloodAxe what do you think?

