### PR TITLE
Improve Cutout augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [Blur](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Blur)
 - [CLAHE](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CLAHE)
 - [ChannelShuffle](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ChannelShuffle)
+- [CoarseDropout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CoarseDropout)
 - [Cutout](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Cutout)
 - [FromFloat](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.FromFloat)
 - [GaussNoise](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GaussNoise)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -938,9 +938,9 @@ class Cutout(ImageOnlyTransform):
         self.min_height = min_height if min_height is not None else max_height
         self.min_width = min_width if min_width is not None else max_width
 
-        assert 0 < self.min_holes and self.min_holes <= self.max_holes
-        assert 0 < self.min_height and self.min_height <= self.max_height
-        assert 0 < self.min_width and self.min_width <= self.max_width
+        assert 0 < self.min_holes <= self.max_holes
+        assert 0 < self.min_height <= self.max_height
+        assert 0 < self.min_width <= self.max_width
 
     def apply(self, image, holes=[], **params):
         return F.cutout(image, holes)

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -986,7 +986,7 @@ class CoarseDropout(ImageOnlyTransform):
     def __init__(self, max_holes=8, max_height=8, max_width=8,
                  min_holes=None, min_height=None, min_width=None,
                  always_apply=False, p=0.5):
-        super().__init__(always_apply, p)
+        super(CoarseDropout, self).__init__(always_apply, p)
         self.max_holes = max_holes
         self.max_height = max_height
         self.max_width = max_width

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1,13 +1,16 @@
 import numpy as np
 import pytest
 
-from albumentations import RandomCrop, PadIfNeeded, VerticalFlip, HorizontalFlip, Flip, Transpose, RandomRotate90, \
-    Rotate, ShiftScaleRotate, CenterCrop, OpticalDistortion, GridDistortion, ElasticTransform, ToGray, RandomGamma, \
-    JpegCompression, HueSaturationValue, RGBShift, Blur, MotionBlur, MedianBlur, \
-    GaussianBlur, GaussNoise, CLAHE, ChannelShuffle, InvertImg, IAAEmboss, IAASuperpixels, IAASharpen, \
-    IAAAdditiveGaussianNoise, IAAPiecewiseAffine, IAAPerspective, Cutout, CoarseDropout, Normalize, ToFloat, FromFloat, \
-    RandomBrightnessContrast, RandomSnow, RandomRain, RandomFog, RandomSunFlare, RandomCropNearBBox, RandomShadow, \
-    RandomSizedCrop
+from albumentations import (
+    RandomCrop, PadIfNeeded, VerticalFlip, HorizontalFlip, Flip, Transpose,
+    RandomRotate90, Rotate, ShiftScaleRotate, CenterCrop, OpticalDistortion,
+    GridDistortion, ElasticTransform, ToGray, RandomGamma, JpegCompression,
+    HueSaturationValue, RGBShift, Blur, MotionBlur, MedianBlur, GaussianBlur,
+    GaussNoise, CLAHE, ChannelShuffle, InvertImg, IAAEmboss, IAASuperpixels,
+    IAASharpen, IAAAdditiveGaussianNoise, IAAPiecewiseAffine, IAAPerspective,
+    Cutout, CoarseDropout, Normalize, ToFloat, FromFloat,
+    RandomBrightnessContrast, RandomSnow, RandomRain, RandomFog,
+    RandomSunFlare, RandomCropNearBBox, RandomShadow, RandomSizedCrop)
 
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -5,7 +5,7 @@ from albumentations import RandomCrop, PadIfNeeded, VerticalFlip, HorizontalFlip
     Rotate, ShiftScaleRotate, CenterCrop, OpticalDistortion, GridDistortion, ElasticTransform, ToGray, RandomGamma, \
     JpegCompression, HueSaturationValue, RGBShift, Blur, MotionBlur, MedianBlur, \
     GaussianBlur, GaussNoise, CLAHE, ChannelShuffle, InvertImg, IAAEmboss, IAASuperpixels, IAASharpen, \
-    IAAAdditiveGaussianNoise, IAAPiecewiseAffine, IAAPerspective, Cutout, Normalize, ToFloat, FromFloat, \
+    IAAAdditiveGaussianNoise, IAAPiecewiseAffine, IAAPerspective, Cutout, CoarseDropout, Normalize, ToFloat, FromFloat, \
     RandomBrightnessContrast, RandomSnow, RandomRain, RandomFog, RandomSunFlare, RandomCropNearBBox, RandomShadow, \
     RandomSizedCrop
 
@@ -26,6 +26,7 @@ from albumentations import RandomCrop, PadIfNeeded, VerticalFlip, HorizontalFlip
     [RandomGamma, {}],
     [ToGray, {}],
     [Cutout, {}],
+    [CoarseDropout, {}],
     [GaussNoise, {}],
     [RandomSnow, {}],
     [RandomRain, {}],
@@ -56,6 +57,7 @@ def test_image_only_augmentations(augmentation_cls, params, image, mask):
     [JpegCompression, {}],
     [ToGray, {}],
     [Cutout, {}],
+    [CoarseDropout, {}],
     [GaussNoise, {}],
     [RandomSnow, {}],
     [RandomRain, {}],
@@ -135,7 +137,6 @@ def test_imgaug_dual_augmentations(augmentation_cls, image, mask):
 
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [
-    [Cutout, {}],
     [JpegCompression, {}],
     [HueSaturationValue, {}],
     [RGBShift, {}],
@@ -152,6 +153,7 @@ def test_imgaug_dual_augmentations(augmentation_cls, image, mask):
     [RandomGamma, {}],
     [ToGray, {}],
     [Cutout, {}],
+    [CoarseDropout, {}],
     [PadIfNeeded, {}],
     [VerticalFlip, {}],
     [HorizontalFlip, {}],
@@ -187,6 +189,7 @@ def test_augmentations_wont_change_input(augmentation_cls, params, image, mask):
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [
     [Cutout, {}],
+    [CoarseDropout, {}],
     [HueSaturationValue, {}],
     [RGBShift, {}],
     [RandomBrightnessContrast, {}],
@@ -200,7 +203,6 @@ def test_augmentations_wont_change_input(augmentation_cls, params, image, mask):
     [InvertImg, {}],
     [RandomGamma, {}],
     [ToGray, {}],
-    [Cutout, {}],
     [PadIfNeeded, {}],
     [VerticalFlip, {}],
     [HorizontalFlip, {}],
@@ -234,6 +236,7 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params, float_i
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [
     [Cutout, {}],
+    [CoarseDropout, {}],
     [JpegCompression, {}],
     [RandomBrightnessContrast, {}],
     [Blur, {}],
@@ -243,7 +246,6 @@ def test_augmentations_wont_change_float_input(augmentation_cls, params, float_i
     [GaussNoise, {}],
     [InvertImg, {}],
     [RandomGamma, {}],
-    [Cutout, {}],
     [VerticalFlip, {}],
     [HorizontalFlip, {}],
     [Flip, {}],
@@ -286,6 +288,7 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, ima
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [
     [Cutout, {}],
+    [CoarseDropout, {}],
     [JpegCompression, {}],
     [HueSaturationValue, {}],
     [RGBShift, {}],
@@ -300,7 +303,6 @@ def test_augmentations_wont_change_shape_grayscale(augmentation_cls, params, ima
     [InvertImg, {}],
     [RandomGamma, {}],
     [ToGray, {}],
-    [Cutout, {}],
     [VerticalFlip, {}],
     [HorizontalFlip, {}],
     [Flip, {}],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,6 +27,7 @@ TEST_SEEDS = (0, 1, 42, 111, 9999)
     [A.RandomGamma, {}],
     [A.ToGray, {}],
     [A.Cutout, {}],
+    [A.CoarseDropout, {}],
     [A.RandomSnow, {}],
     [A.RandomRain, {}],
     [A.RandomFog, {}],
@@ -78,7 +79,8 @@ def test_augmentations_serialization(augmentation_cls, params, p, seed, image, m
     [A.GaussNoise, {'var_limit': (20, 90)}],
     [A.CLAHE, {'clip_limit': 2, 'tile_grid_size': (12, 12)}],
     [A.RandomGamma, {'gamma_limit': (10, 90)}],
-    [A.Cutout, {'max_holes': 4, 'max_height': 4, 'max_width': 4}],
+    [A.Cutout, {'num_holes': 4, 'max_h_size': 4, 'max_w_size': 4}],
+    [A.CoarseDropout, {'max_holes': 4, 'max_height': 4, 'max_width': 4}],
     [A.RandomSnow, {'snow_point_lower': 0.2, 'snow_point_upper': 0.4, 'brightness_coeff': 4}],
     [A.RandomRain, {
         'slant_lower': -5,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -78,7 +78,7 @@ def test_augmentations_serialization(augmentation_cls, params, p, seed, image, m
     [A.GaussNoise, {'var_limit': (20, 90)}],
     [A.CLAHE, {'clip_limit': 2, 'tile_grid_size': (12, 12)}],
     [A.RandomGamma, {'gamma_limit': (10, 90)}],
-    [A.Cutout, {'num_holes': 4, 'max_h_size': 4, 'max_w_size': 4}],
+    [A.Cutout, {'max_holes': 4, 'max_height': 4, 'max_width': 4}],
     [A.RandomSnow, {'snow_point_lower': 0.2, 'snow_point_upper': 0.4, 'brightness_coeff': 4}],
     [A.RandomRain, {
         'slant_lower': -5,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -205,6 +205,7 @@ def test_force_apply():
     [A.ChannelShuffle, {}],
     [A.GaussNoise, {}],
     [A.Cutout, {}],
+    [A.CoarseDropout, {}],
     [A.JpegCompression, {}],
     [A.HueSaturationValue, {}],
     [A.RGBShift, {}],


### PR DESCRIPTION
* Allow cutting out random number of regions.
* Allow cutting out regions of random size.
* Slightly simplify the code and remove the code which always creates
  patches of even height and width.
* Add sanity checks for non-negative parameters.
* Fix documentation which mentions squares being zeroed out from the
  image while the applied patches can be rectangular.
* Change tests so that serialization is provided with new parameters.

Implements the first part of #263.