### PR TITLE
Add `get_transform_init_args_names` to `NoOp`

### DIFF
--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -248,6 +248,6 @@ class NoOp(DualTransform):
 
     def apply_to_mask(self, img, **params):
         return img
-       
+
     def get_transform_init_args_names(self):
         return tuple()

--- a/albumentations/core/transforms_interface.py
+++ b/albumentations/core/transforms_interface.py
@@ -248,3 +248,6 @@ class NoOp(DualTransform):
 
     def apply_to_mask(self, img, **params):
         return img
+       
+    def get_transform_init_args_names(self):
+        return tuple()


### PR DESCRIPTION
Add missing implementation for `get_transform_init_args_names` to `NoOp` to make it serializable