### PR TITLE
Changed GaussNoise mean to zero, instead of setting mean to var

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1811,7 +1811,7 @@ class GaussNoise(ImageOnlyTransform):
     def get_params_dependent_on_targets(self, params):
         image = params['image']
         var = random.uniform(self.var_limit[0], self.var_limit[1])
-        mean = var
+        mean = 0.
         sigma = var ** 0.5
         random_state = np.random.RandomState(random.randint(0, 2 ** 32 - 1))
         gauss = random_state.normal(mean, sigma, image.shape)


### PR DESCRIPTION
Hello, this is in reference to Issue #313. @TontonTremblay and I noticed that the setting of `GaussNoise` `mean` is set to `var`. Therefore, `GaussNoise` will always brighten the image, because the resulting noise vector `gauss` has non-zero mean.

I believe the intended behavior is to apply Gaussian white noise (i.e., zero-mean noise) to the image, which it does now after this fix. This also means that, with this fix, `GaussNoise` will no longer always brighten the image.