### PR TITLE
Allow invisible keypoints before transformation

### DIFF
--- a/albumentations/core/composition.py
+++ b/albumentations/core/composition.py
@@ -246,7 +246,8 @@ def data_preprocessing(data_name, params, check_fn, convert_fn, data):
     if params['format'] == 'albumentations':
         check_fn(data[data_name])
     else:
-        data[data_name] = convert_fn(data[data_name], params['format'], rows, cols, check_validity=True)
+        data[data_name] = convert_fn(data[data_name], params['format'], rows, cols,
+                                     check_validity=bool(params.get('remove_invisible', True)))
 
     return data
 


### PR DESCRIPTION
Hello, @TontonTremblay and I noticed that although there is a way to keep keypoints that become invisible after transformation by setting the param `remove_invisible` to `False`, providing invisible keypoints _before_ the transformation will still cause a validity check error.

This fix will use the value of `remove_invisible` to determine whether invisible keypoints should be kept in the method `data_preprocessing`, similar to how it currently is done for the method `data_postprocessing`.

The usage case is when you are tracking a collection of keypoints through transformations, but some of the keypoints could be invisible to begin with.