### PR TITLE
deprecate totensor

### DIFF
--- a/albumentations/torch/__init__.py
+++ b/albumentations/torch/__init__.py
@@ -1,4 +1,0 @@
-from albumentations.pytorch import *
-import warnings
-warnings.warn("`torch` module inside albumentations is deprecated and will be deleted in 0.3.0. "
-              "please use `pytorch` module instead", DeprecationWarning)

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -2,24 +2,20 @@ import numpy as np
 import torch
 
 import albumentations as A
-from albumentations.pytorch.transforms import ToTensor
+from albumentations.pytorch.transforms import ImgToTensor
 
 
 def test_torch_to_tensor_augmentations(image, mask):
-    aug = ToTensor()
-    data = aug(image=image, mask=mask, force_apply=True)
-    assert data['image'].dtype == torch.float32
-    assert data['mask'].dtype == torch.float32
+    aug = ImgToTensor()
+    data = aug(image=image, force_apply=True)
+    assert data['image'].dtype == torch.uint8
 
 
 def test_additional_targets_for_totensor():
     aug = A.Compose(
-        [ToTensor(num_classes=4)], additional_targets={'image2': 'image', 'mask2': 'mask'})
+        [ImgToTensor()], additional_targets={'image2': 'image'})
     for i in range(10):
         image1 = np.random.randint(low=0, high=256, size=(100, 100, 3), dtype=np.uint8)
         image2 = image1.copy()
-        mask1 = np.random.randint(low=0, high=256, size=(100, 100, 4), dtype=np.uint8)
-        mask2 = mask1.copy()
-        res = aug(image=image1, image2=image2, mask=mask1, mask2=mask2)
+        res = aug(image=image1, image2=image2)
         assert np.array_equal(res['image'], res['image2'])
-        assert np.array_equal(res['mask'], res['mask2'])


### PR DESCRIPTION
current ToTensor version leads to a lot of questions. we have to deprecate it because it's bad