### PR TITLE
Feature CropNonEmptyMaskIfExists augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,39 +145,40 @@ Pixel-level transforms will change just an input image and will leave any additi
 ## Spatial-level transforms
 Spatial-level transforms will simultaneously change both an input image as well as additional targets such as masks, bounding boxes, and keypoints. The following table shows which additional targets are supported by each transform.
 
-| Transform                                                                                                                                                         | Image | Masks | BBoxes | Keypoints |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :---: | :----: | :-------: |
-| [CenterCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CenterCrop)                           | ✓     | ✓     | ✓      | ✓         |
-| [Crop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Crop)                                       | ✓     | ✓     | ✓      |           |
-| [ElasticTransform](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ElasticTransform)               | ✓     | ✓     |        |           |
-| [Flip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Flip)                                       | ✓     | ✓     | ✓      | ✓         |
-| [GridDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GridDistortion)                   | ✓     | ✓     |        |           |
-| [HorizontalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.HorizontalFlip)                   | ✓     | ✓     | ✓      | ✓         |
-| [IAAAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAAffine)                                    | ✓     | ✓     | ✓      | ✓         |
-| [IAACropAndPad](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAACropAndPad)                            | ✓     | ✓     | ✓      | ✓         |
-| [IAAFliplr](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFliplr)                                    | ✓     | ✓     | ✓      | ✓         |
-| [IAAFlipud](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFlipud)                                    | ✓     | ✓     | ✓      | ✓         |
-| [IAAPerspective](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPerspective)                          | ✓     | ✓     | ✓      | ✓         |
-| [IAAPiecewiseAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPiecewiseAffine)                  | ✓     | ✓     | ✓      | ✓         |
-| [Lambda](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Lambda)                                   | ✓     | ✓     | ✓      | ✓         |
-| [LongestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.LongestMaxSize)                   | ✓     | ✓     | ✓      |           |
-| NoOp                                                                                                                                                              | ✓     | ✓     | ✓      | ✓         |
-| [OpticalDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.OpticalDistortion)             | ✓     | ✓     |        |           |
-| [PadIfNeeded](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.PadIfNeeded)                         | ✓     | ✓     | ✓      | ✓         |
-| [RandomCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCrop)                           | ✓     | ✓     | ✓      | ✓         |
-| [RandomCropNearBBox](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCropNearBBox)           | ✓     | ✓     | ✓      |           |
-| [RandomGridShuffle](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomGridShuffle)             | ✓     | ✓     |        |           |
-| [RandomResizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomResizedCrop)             | ✓     | ✓     | ✓      | ✓         |
-| [RandomRotate90](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomRotate90)                   | ✓     | ✓     | ✓      | ✓         |
-| [RandomScale](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomScale)                         | ✓     | ✓     | ✓      | ✓         |
-| [RandomSizedBBoxSafeCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedBBoxSafeCrop) | ✓     | ✓     | ✓      |           |
-| [RandomSizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedCrop)                 | ✓     | ✓     | ✓      | ✓         |
-| [Resize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Resize)                                   | ✓     | ✓     | ✓      |           |
-| [Rotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Rotate)                                   | ✓     | ✓     | ✓      | ✓         |
-| [ShiftScaleRotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ShiftScaleRotate)               | ✓     | ✓     | ✓      | ✓         |
-| [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                 | ✓     | ✓     | ✓      |           |
-| [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                             | ✓     | ✓     | ✓      |           |
-| [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                       | ✓     | ✓     | ✓      | ✓         |
+| Transform                                                                                                                                                           | Image | Masks | BBoxes | Keypoints |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :---: | :----: | :-------: |
+| [CenterCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CenterCrop)                             | ✓     | ✓     | ✓      | ✓         |
+| [Crop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Crop)                                         | ✓     | ✓     | ✓      |           |
+| [CropNonEmptyMaskIfExists](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CropNonEmptyMaskIfExists) | ✓     | ✓     |        |           |
+| [ElasticTransform](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ElasticTransform)                 | ✓     | ✓     |        |           |
+| [Flip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Flip)                                         | ✓     | ✓     | ✓      | ✓         |
+| [GridDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GridDistortion)                     | ✓     | ✓     |        |           |
+| [HorizontalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.HorizontalFlip)                     | ✓     | ✓     | ✓      | ✓         |
+| [IAAAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAAffine)                                      | ✓     | ✓     | ✓      | ✓         |
+| [IAACropAndPad](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAACropAndPad)                              | ✓     | ✓     | ✓      | ✓         |
+| [IAAFliplr](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFliplr)                                      | ✓     | ✓     | ✓      | ✓         |
+| [IAAFlipud](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFlipud)                                      | ✓     | ✓     | ✓      | ✓         |
+| [IAAPerspective](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPerspective)                            | ✓     | ✓     | ✓      | ✓         |
+| [IAAPiecewiseAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPiecewiseAffine)                    | ✓     | ✓     | ✓      | ✓         |
+| [Lambda](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Lambda)                                     | ✓     | ✓     | ✓      | ✓         |
+| [LongestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.LongestMaxSize)                     | ✓     | ✓     | ✓      |           |
+| NoOp                                                                                                                                                                | ✓     | ✓     | ✓      | ✓         |
+| [OpticalDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.OpticalDistortion)               | ✓     | ✓     |        |           |
+| [PadIfNeeded](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.PadIfNeeded)                           | ✓     | ✓     | ✓      | ✓         |
+| [RandomCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCrop)                             | ✓     | ✓     | ✓      | ✓         |
+| [RandomCropNearBBox](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCropNearBBox)             | ✓     | ✓     | ✓      |           |
+| [RandomGridShuffle](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomGridShuffle)               | ✓     | ✓     |        |           |
+| [RandomResizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomResizedCrop)               | ✓     | ✓     | ✓      | ✓         |
+| [RandomRotate90](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomRotate90)                     | ✓     | ✓     | ✓      | ✓         |
+| [RandomScale](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomScale)                           | ✓     | ✓     | ✓      | ✓         |
+| [RandomSizedBBoxSafeCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedBBoxSafeCrop)   | ✓     | ✓     | ✓      |           |
+| [RandomSizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedCrop)                   | ✓     | ✓     | ✓      | ✓         |
+| [Resize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Resize)                                     | ✓     | ✓     | ✓      |           |
+| [Rotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Rotate)                                     | ✓     | ✓     | ✓      | ✓         |
+| [ShiftScaleRotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ShiftScaleRotate)                 | ✓     | ✓     | ✓      | ✓         |
+| [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      |           |
+| [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      |           |
+| [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                         | ✓     | ✓     | ✓      | ✓         |
 
 ## Migrating from torchvision to albumentations
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -896,7 +896,7 @@ class CropNonEmptyMaskIfExists(DualTransform):
 
     def __init__(self, crop_height, crop_width, ignore_values=None,
                  ignore_channels=None, always_apply=True, p=1.):
-        super(CropWithMaskIfExist, self).__init__(always_apply, p)
+        super(CropNonEmptyMaskIfExists, self).__init__(always_apply, p)
 
         if ignore_values is not None and not isinstance(ignore_values, list):
             raise ValueError('Expected `ignore_values` of type `list`, got `{}`'.format(type(ignore_values)))

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -882,8 +882,8 @@ class CropNonEmptyMaskIfExists(DualTransform):
     """Crop area with mask if mask is non-empty, else make random crop.
 
     Args:
-        crop_height (int): vertical size of crop in pixels
-        crop_width (int): horizontal size of crop in pixels
+        height (int): vertical size of crop in pixels
+        width (int): horizontal size of crop in pixels
         ignore_values (list of int): values to ignore in mask, `0` values are always ignored
             (e.g. if background value is 5 set `ignore_values=[5]` to ignore)
         ignore_channels (list of int): channels to ignore in mask

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -76,11 +76,11 @@ class CropWithMaskIfExist(DualTransform):
 
         if self.ignore_indexes is not None:
             ignore_values_np = np.array(self.ignore_values)
-            mask = np.where(mask.isin(ignore_values_np), mask, 0)
+            mask = np.where(np.isin(mask, ignore_values_np), 0, mask)
 
         if mask.ndim == 3 and self.ignore_channels is not None:
             target_channels = np.array([ch for ch in range(mask.shape[-1])
-                                        if ch not in  self.ignore_indexes])
+                                        if ch not in  self.ignore_channels])
             mask = np.take(mask, target_channels, axis=-1)
 
         if self.crop_height > h or self.crop_width > w:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -21,96 +21,12 @@ __all__ = [
     'RandomBrightness', 'RandomContrast', 'MotionBlur', 'MedianBlur',
     'GaussianBlur', 'GaussNoise', 'CLAHE', 'ChannelShuffle', 'InvertImg',
     'ToGray', 'JpegCompression', 'Cutout', 'CoarseDropout', 'ToFloat',
-    'FromFloat', 'Crop', 'CropWithMaskIfExist', 'RandomScale', 'LongestMaxSize', 'SmallestMaxSize',
+    'FromFloat', 'Crop', 'CropNonEmptyMaskIfExists', 'RandomScale', 'LongestMaxSize', 'SmallestMaxSize',
     'Resize', 'RandomSizedCrop', 'RandomResizedCrop', 'RandomBrightnessContrast',
     'RandomCropNearBBox', 'RandomSizedBBoxSafeCrop', 'RandomSnow',
     'RandomRain', 'RandomFog', 'RandomSunFlare', 'RandomShadow', 'Lambda',
     'ChannelDropout', 'ISONoise', 'Solarize', 'Equalize'
 ]
-
-
-class CropWithMaskIfExist(DualTransform):
-    """Crop area with mask if mask is non-empty, else make random crop.
-
-    Args:
-        crop_height (int): vertical size of crop in pixels
-        crop_width (int): horizontal size of crop in pixels
-        ignore_values (list of int): values to ignore in mask
-            (e.g. if background value is 0 set `ignore_values=[0]` to ignore)
-        ignore_channels (list of int): channels to ignore in mask
-            (e.g. if background is a first channel set `ignore_channels=[0]` to ignore)
-        p (float): probability of applying the transform. Default: 1.0.
-
-    Targets:
-        image, mask
-
-    Image types:
-        uint8, float32
-
-    """
-
-    def __init__(self, crop_height, crop_width, ignore_values=None,
-                 ignore_channels=None, always_apply=True, p=1.):
-        super(CropWithMaskIfExist, self).__init__(always_apply, p)
-
-        if self.ignore_values is not None and not isinstance(ignore_values, list):
-            raise ValueError('Expected `ignore_values` of type `list`, got `{}`'.format(type(ignore_values)))
-        if self.ignore_values is not None and not isinstance(ignore_values, list):
-            raise ValueError('Expected `ignore_channels` of type `list`, got `{}`'.format(type(ignore_values)))
-
-        self.crop_height = crop_height
-        self.crop_width = crop_width
-        self.ignore_values = ignore_values
-        self.ignore_channels = ignore_channels
-
-    def apply(self, img, x_min=0, x_max=0, y_min=0, y_max=0, **params):
-        return F.crop(img, x_min, y_min, x_max, y_max)
-
-    @property
-    def targets_as_params(self):
-        return ['mask']
-
-    def get_params_dependent_on_targets(self, params):
-        mask = params['mask']
-        h, w = mask.shape[:2]
-
-        if self.ignore_indexes is not None:
-            ignore_values_np = np.array(self.ignore_values)
-            mask = np.where(np.isin(mask, ignore_values_np), 0, mask)
-
-        if mask.ndim == 3 and self.ignore_channels is not None:
-            target_channels = np.array([ch for ch in range(mask.shape[-1])
-                                        if ch not in  self.ignore_channels])
-            mask = np.take(mask, target_channels, axis=-1)
-
-        if self.crop_height > h or self.crop_width > w:
-            raise ValueError('Crop size ({},{}) is larger than image ({},{})'.format(
-                self.crop_height, self.crop_width, h, w))
-
-        if mask.sum() == 0:
-            x_min = np.random.randint(w - self.crop_width + 1)
-            y_min = np.random.randint(h - self.crop_height + 1)
-        else:
-            mask = mask.sum(axis=-1) if mask.ndim == 3 else mask
-            non_zero_yx = np.argwhere(mask)
-            y, x = random.choice(non_zero_yx)
-            x_min = x - np.random.randint(self.crop_width)
-            y_min = y - np.random.randint(self.crop_height)
-            x_min = np.clip(x_min, 0, w - self.crop_width)
-            y_min = np.clip(y_min, 0, h - self.crop_height)
-
-        x_max = x_min + self.crop_width
-        y_max = y_min + self.crop_height
-
-        return {
-            'x_min': x_min,
-            'x_max': x_max,
-            'y_min': y_min,
-            'y_max': y_max,
-        }
-
-    def get_transform_init_args_names(self):
-        return ('crop_height', 'crop_width', 'ignore_values', 'ignore_channels')
 
 
 class PadIfNeeded(DualTransform):
@@ -961,7 +877,87 @@ class RandomSizedBBoxSafeCrop(DualTransform):
     def get_transform_init_args_names(self):
         return ('height', 'width', 'erosion_rate', 'interpolation')
 
+    
+class CropNonEmptyMaskIfExists(A.DualTransform):
+    """Crop area with mask if mask is non-empty, else make random crop.
+    Args:
+        crop_height (int): vertical size of crop in pixels
+        crop_width (int): horizontal size of crop in pixels
+        ignore_values (list of int): values to ignore in mask
+            (e.g. if background value is 0 set `ignore_values=[0]` to ignore)
+        ignore_channels (list of int): channels to ignore in mask
+            (e.g. if background is a first channel set `ignore_channels=[0]` to ignore)
+        p (float): probability of applying the transform. Default: 1.0.
+    Targets:
+        image, mask
+    Image types:
+        uint8, float32
+    """
 
+    def __init__(self, crop_height, crop_width, ignore_values=None,
+                 ignore_channels=None, always_apply=True, p=1.):
+        super(CropWithMaskIfExist, self).__init__(always_apply, p)
+
+        if ignore_values is not None and not isinstance(ignore_values, list):
+            raise ValueError('Expected `ignore_values` of type `list`, got `{}`'.format(type(ignore_values)))
+        if ignore_channels is not None and not isinstance(ignore_channels, list):
+            raise ValueError('Expected `ignore_channels` of type `list`, got `{}`'.format(type(ignore_channels)))
+
+        self.crop_height = crop_height
+        self.crop_width = crop_width
+        self.ignore_values = ignore_values
+        self.ignore_channels = ignore_channels
+
+    def apply(self, img, x_min=0, x_max=0, y_min=0, y_max=0, **params):
+        return F.crop(img, x_min, y_min, x_max, y_max)
+
+    @property
+    def targets_as_params(self):
+        return ['mask']
+
+    def get_params_dependent_on_targets(self, params):
+        mask = params['mask']
+        h, w = mask.shape[:2]
+
+        if self.ignore_values is not None:
+            ignore_values_np = np.array(self.ignore_values)
+            mask = np.where(np.isin(mask, ignore_values_np), 0, mask)
+
+        if mask.ndim == 3 and self.ignore_channels is not None:
+            target_channels = np.array([ch for ch in range(mask.shape[-1])
+                                        if ch not in  self.ignore_channels])
+            mask = np.take(mask, target_channels, axis=-1)
+
+        if self.crop_height > h or self.crop_width > w:
+            raise ValueError('Crop size ({},{}) is larger than image ({},{})'.format(
+                self.crop_height, self.crop_width, h, w))
+
+        if mask.sum() == 0:
+            x_min = np.random.randint(w - self.crop_width + 1)
+            y_min = np.random.randint(h - self.crop_height + 1)
+        else:
+            mask = mask.sum(axis=-1) if mask.ndim == 3 else mask
+            non_zero_yx = np.argwhere(mask)
+            y, x = random.choice(non_zero_yx)
+            x_min = x - np.random.randint(self.crop_width)
+            y_min = y - np.random.randint(self.crop_height)
+            x_min = np.clip(x_min, 0, w - self.crop_width)
+            y_min = np.clip(y_min, 0, h - self.crop_height)
+
+        x_max = x_min + self.crop_width
+        y_max = y_min + self.crop_height
+
+        return {
+            'x_min': x_min,
+            'x_max': x_max,
+            'y_min': y_min,
+            'y_max': y_max,
+        }
+
+    def get_transform_init_args_names(self):
+        return ('crop_height', 'crop_width', 'ignore_values', 'ignore_channels')
+    
+    
 class OpticalDistortion(DualTransform):
     """
     Targets:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -878,7 +878,7 @@ class RandomSizedBBoxSafeCrop(DualTransform):
         return ('height', 'width', 'erosion_rate', 'interpolation')
 
     
-class CropNonEmptyMaskIfExists(A.DualTransform):
+class CropNonEmptyMaskIfExists(DualTransform):
     """Crop area with mask if mask is non-empty, else make random crop.
     Args:
         crop_height (int): vertical size of crop in pixels

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -14,7 +14,7 @@ from albumentations import (
     Cutout, CoarseDropout, Normalize, ToFloat, FromFloat,
     RandomBrightnessContrast, RandomSnow, RandomRain, RandomFog,
     RandomSunFlare, RandomCropNearBBox, RandomShadow, RandomSizedCrop, RandomResizedCrop,
-    ChannelDropout, ISONoise, Solarize, Equalize)
+    ChannelDropout, ISONoise, Solarize, Equalize, CropNonEmptyMaskIfExists)
 
 
 @pytest.mark.parametrize(['augmentation_cls', 'params'], [
@@ -100,6 +100,7 @@ def test_image_only_augmentations_with_float_values(augmentation_cls, params, fl
     [ElasticTransform, {}],
     [CenterCrop, {'height': 10, 'width': 10}],
     [RandomCrop, {'height': 10, 'width': 10}],
+    [CropNonEmptyMaskIfExists, {'height': 10, 'width': 10}],
     [RandomResizedCrop, {'height': 10, 'width': 10}],
     [RandomSizedCrop, {'min_max_height': (4, 8), 'height': 10, 'width': 10}],
     [ISONoise, {}],
@@ -126,6 +127,7 @@ def test_dual_augmentations(augmentation_cls, params, image, mask):
     [ElasticTransform, {}],
     [CenterCrop, {'height': 10, 'width': 10}],
     [RandomCrop, {'height': 10, 'width': 10}],
+    [CropNonEmptyMaskIfExists, {'height': 10, 'width': 10}],
     [RandomResizedCrop, {'height': 10, 'width': 10}],
     [RandomSizedCrop, {'min_max_height': (4, 8), 'height': 10, 'width': 10}],
     [RandomGridShuffle, {}]
@@ -186,6 +188,7 @@ def test_imgaug_dual_augmentations(augmentation_cls, image, mask):
     [ElasticTransform, {}],
     [CenterCrop, {'height': 10, 'width': 10}],
     [RandomCrop, {'height': 10, 'width': 10}],
+    [CropNonEmptyMaskIfExists, {'height': 10, 'width': 10}],
     [RandomResizedCrop, {'height': 10, 'width': 10}],
     [RandomSizedCrop, {'min_max_height': (4, 8), 'height': 10, 'width': 10}],
     [Normalize, {}],

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -151,6 +151,7 @@ def test_augmentations_serialization(augmentation_cls, params, p, seed, image, m
     }],
     [A.CenterCrop, {'height': 10, 'width': 10}],
     [A.RandomCrop, {'height': 10, 'width': 10}],
+    [A.CropNonEmptyMaskIfExists, {'height': 10, 'width': 10}],
     [A.RandomSizedCrop, {'min_max_height': (4, 8), 'height': 10, 'width': 10}],
     [A.Crop, {'x_max': 64, 'y_max': 64}],
     [A.ToFloat, {'max_value': 16536}],

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -314,3 +314,44 @@ def test_equalize():
         return mask
     aug = A.Equalize(mask=mask_func, mask_params=['test'], p=1)
     assert np.all(aug(image=img, test=mask)['image'] == F.equalize(img, mask=mask))
+    
+    
+def test_crop_non_empty_mask():
+    
+    def _test_crop(mask, crop, aug, n=1):
+        for _ in range(n):
+            augmented = aug(image=mask, mask=mask)
+            np.testing.assert_array_equal(augmented['image'], crop)
+            np.testing.assert_array_equal(augmented['mask'], crop)
+    
+    mask_1 = np.zeros([128, 128])
+    mask_1[127, 127] = 1
+    crop_1 = np.array([[1]])
+    aug_1 = A.CropNonEmptyMaskIfExists(1, 1)
+    
+    mask_2 = np.zeros([128, 128])
+    crop_2 = np.array([[0]])
+    aug_2 = A.CropNonEmptyMaskIfExists(1, 1)
+    
+    mask_3 = np.zeros([128, 128])
+    mask_3[0, 0] = 1
+    mask_3[65, 65] = 2
+    crop_3 = np.array([[1]])
+    aug_3 = A.CropNonEmptyMaskIfExists(1, 1, ignore_values=[2])
+    
+    mask_4 = np.zeros([128, 128, 2])
+    mask_4[64, 64, 0] = 1
+    mask_4[65, 65, 1] = 2
+    crop_4 = np.array([[[1, 0]]])
+    aug_4 = A.CropNonEmptyMaskIfExists(1, 1, ignore_channels=[1])
+    
+    mask_5 = np.random.random([10, 10, 3])
+    crop_5 = mask_5
+    aug_5 = A.CropNonEmptyMaskIfExists(10, 10)
+    
+    _test_crop(mask_1, crop_1, aug_1, n=1)
+    _test_crop(mask_2, crop_2, aug_2, n=1)
+    _test_crop(mask_3, crop_3, aug_3, n=4)
+    _test_crop(mask_4, crop_4, aug_4, n=4)
+    _test_crop(mask_5, crop_5, aug_5, n=1)
+    

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -314,44 +314,47 @@ def test_equalize():
         return mask
     aug = A.Equalize(mask=mask_func, mask_params=['test'], p=1)
     assert np.all(aug(image=img, test=mask)['image'] == F.equalize(img, mask=mask))
-    
-    
+
+
 def test_crop_non_empty_mask():
-    
+
     def _test_crop(mask, crop, aug, n=1):
         for _ in range(n):
             augmented = aug(image=mask, mask=mask)
             np.testing.assert_array_equal(augmented['image'], crop)
             np.testing.assert_array_equal(augmented['mask'], crop)
-    
-    mask_1 = np.zeros([128, 128])
-    mask_1[127, 127] = 1
+
+    # test general case
+    mask_1 = np.zeros([10, 10])
+    mask_1[0, 0] = 1
     crop_1 = np.array([[1]])
     aug_1 = A.CropNonEmptyMaskIfExists(1, 1)
-    
-    mask_2 = np.zeros([128, 128])
+
+    # test empty mask
+    mask_2 = np.zeros([10, 10])
     crop_2 = np.array([[0]])
     aug_2 = A.CropNonEmptyMaskIfExists(1, 1)
-    
-    mask_3 = np.zeros([128, 128])
-    mask_3[0, 0] = 1
-    mask_3[65, 65] = 2
-    crop_3 = np.array([[1]])
-    aug_3 = A.CropNonEmptyMaskIfExists(1, 1, ignore_values=[2])
-    
-    mask_4 = np.zeros([128, 128, 2])
-    mask_4[64, 64, 0] = 1
-    mask_4[65, 65, 1] = 2
+
+    # test ignore values
+    mask_3 = np.ones([2, 2])
+    mask_3[0, 0] = 2
+    crop_3 = np.array([[2]])
+    aug_3 = A.CropNonEmptyMaskIfExists(1, 1, ignore_values=[1])
+
+    # test ignore channels
+    mask_4 = np.zeros([2, 2, 2])
+    mask_4[0, 0, 0] = 1
+    mask_4[1, 1, 1] = 2
     crop_4 = np.array([[[1, 0]]])
     aug_4 = A.CropNonEmptyMaskIfExists(1, 1, ignore_channels=[1])
-    
+
+    # test full size crop
     mask_5 = np.random.random([10, 10, 3])
     crop_5 = mask_5
     aug_5 = A.CropNonEmptyMaskIfExists(10, 10)
-    
+
     _test_crop(mask_1, crop_1, aug_1, n=1)
     _test_crop(mask_2, crop_2, aug_2, n=1)
-    _test_crop(mask_3, crop_3, aug_3, n=4)
-    _test_crop(mask_4, crop_4, aug_4, n=4)
+    _test_crop(mask_3, crop_3, aug_3, n=5)
+    _test_crop(mask_4, crop_4, aug_4, n=5)
     _test_crop(mask_5, crop_5, aug_5, n=1)
-    

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -353,8 +353,14 @@ def test_crop_non_empty_mask():
     crop_5 = mask_5
     aug_5 = A.CropNonEmptyMaskIfExists(10, 10)
 
+    mask_6 = np.zeros([10, 10, 3])
+    mask_6[0, 0, 0] = 0
+    crop_6 = mask_6
+    aug_6 = A.CropNonEmptyMaskIfExists(10, 10, ignore_values=[1])
+
     _test_crop(mask_1, crop_1, aug_1, n=1)
     _test_crop(mask_2, crop_2, aug_2, n=1)
     _test_crop(mask_3, crop_3, aug_3, n=5)
     _test_crop(mask_4, crop_4, aug_4, n=5)
     _test_crop(mask_5, crop_5, aug_5, n=1)
+    _test_crop(mask_6, crop_6, aug_6, n=10)


### PR DESCRIPTION
Add crop augmentation which depends on input mask:
 - If mask is not empty, crop area with mask objects
 - If mask is empty make random crop

Mask `0` values are interpreted as "empty", additional "empty" values can be specified with `ignore_values` parameter, or you can ignore whole mask channels with `ignore_channels` parameter. 