### PR TITLE
Fix GammaTransform int as tuple, division by zero

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1077,9 +1077,9 @@ def channel_dropout(img, channels_to_drop, fill_value=0):
 
 
 @preserve_shape
-def gamma_transform(img, gamma):
+def gamma_transform(img, gamma, eps=1e-7):
     if img.dtype == np.uint8:
-        invGamma = 1.0 / gamma
+        invGamma = 1.0 / (gamma + eps)
         table = (np.arange(0, 256.0 / 255, 1.0 / 255) ** invGamma) * 255
         img = cv2.LUT(img, table.astype(np.uint8))
     else:

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2251,12 +2251,13 @@ class RandomGamma(ImageOnlyTransform):
         uint8, float32
     """
 
-    def __init__(self, gamma_limit=(80, 120), always_apply=False, p=0.5):
+    def __init__(self, gamma_limit=(80, 120), eps=1e-7, always_apply=False, p=0.5):
         super(RandomGamma, self).__init__(always_apply, p)
-        self.gamma_limit = gamma_limit
+        self.gamma_limit = to_tuple(gamma_limit)
+        self.eps = eps
 
     def apply(self, img, gamma=1, **params):
-        return F.gamma_transform(img, gamma=gamma)
+        return F.gamma_transform(img, gamma=gamma, eps=self.eps)
 
     def get_params(self):
         return {
@@ -2264,7 +2265,7 @@ class RandomGamma(ImageOnlyTransform):
         }
 
     def get_transform_init_args_names(self):
-        return ('gamma_limit',)
+        return ('gamma_limit', 'eps',)
 
 
 class ToGray(ImageOnlyTransform):


### PR DESCRIPTION
#343 
What a lower bound for gamma?
I think, values in range `[-inf, 0)` will give strange (no intuitive) results.
Maybe need call `to_tuple(gamma_limit, low=0)`?