### PR TITLE
Fix transform urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      |           |
 | [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      |           |
 | [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                         | ✓     | ✓     | ✓      | ✓         |
+
 ## Migrating from torchvision to albumentations
 
 Migrating from torchvision to albumentations is simple - you just need to change a few lines of code.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to adjust image augmentation parameters and see the resulting images.
 
 [Evegene Khvedchenya](https://www.linkedin.com/in/cvtalks/)
 
-[Druzhinin Mikhail](https://www.linkedin.com/in/mikhail-druzhinin-548229100/)
+[Mikhail Druzhinin](https://www.linkedin.com/in/mikhail-druzhinin-548229100/)
 
 ## Installation
 
@@ -120,10 +120,10 @@ Pixel-level transforms will change just an input image and will leave any additi
 - [GaussNoise](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GaussNoise)
 - [GaussianBlur](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GaussianBlur)
 - [HueSaturationValue](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.HueSaturationValue)
-- [IAAAdditiveGaussianNoise](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAAdditiveGaussianNoise)
-- [IAAEmboss](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAEmboss)
-- [IAASharpen](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAASharpen)
-- [IAASuperpixels](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAASuperpixels)
+- [IAAAdditiveGaussianNoise](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAAdditiveGaussianNoise)
+- [IAAEmboss](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAEmboss)
+- [IAASharpen](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAASharpen)
+- [IAASuperpixels](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAASuperpixels)
 - [ISONoise](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ISONoise)
 - [ImageCompression](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ImageCompression)
 - [InvertImg](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.InvertImg)
@@ -158,12 +158,12 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [Flip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Flip)                                         | ✓     | ✓     | ✓      | ✓         |
 | [GridDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GridDistortion)                     | ✓     | ✓     |        |           |
 | [HorizontalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.HorizontalFlip)                     | ✓     | ✓     | ✓      | ✓         |
-| [IAAAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAAffine)                                      | ✓     | ✓     | ✓      | ✓         |
-| [IAACropAndPad](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAACropAndPad)                              | ✓     | ✓     | ✓      | ✓         |
-| [IAAFliplr](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFliplr)                                      | ✓     | ✓     | ✓      | ✓         |
-| [IAAFlipud](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAFlipud)                                      | ✓     | ✓     | ✓      | ✓         |
-| [IAAPerspective](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPerspective)                            | ✓     | ✓     | ✓      | ✓         |
-| [IAAPiecewiseAffine](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.imgaug.transforms.IAAPiecewiseAffine)                    | ✓     | ✓     | ✓      | ✓         |
+| [IAAAffine](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAAffine)                                             | ✓     | ✓     | ✓      | ✓         |
+| [IAACropAndPad](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAACropAndPad)                                     | ✓     | ✓     | ✓      | ✓         |
+| [IAAFliplr](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAFliplr)                                             | ✓     | ✓     | ✓      | ✓         |
+| [IAAFlipud](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAFlipud)                                             | ✓     | ✓     | ✓      | ✓         |
+| [IAAPerspective](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAPerspective)                                   | ✓     | ✓     | ✓      | ✓         |
+| [IAAPiecewiseAffine](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAPiecewiseAffine)                           | ✓     | ✓     | ✓      | ✓         |
 | [Lambda](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Lambda)                                     | ✓     | ✓     | ✓      | ✓         |
 | [LongestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.LongestMaxSize)                     | ✓     | ✓     | ✓      |           |
 | NoOp                                                                                                                                                                | ✓     | ✓     | ✓      | ✓         |
@@ -183,7 +183,6 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      |           |
 | [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      |           |
 | [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                         | ✓     | ✓     | ✓      | ✓         |
-
 ## Migrating from torchvision to albumentations
 
 Migrating from torchvision to albumentations is simple - you just need to change a few lines of code.

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -18,9 +18,10 @@ IGNORED_CLASSES = {
 }
 
 
-READTHEDOCS_TEMPLATE = "[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations"
-TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE + ".augmentations.transforms.{name})"
-IMGAUG_TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE + ".imgaug.transforms.{name})"
+READTHEDOCS_TEMPLATE_ALBU = '[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations'
+READTHEDOCS_TEMPLATE_IMGAUG = '[{name}](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations'
+TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_ALBU + '.augmentations.transforms.{name})'
+IMGAUG_TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_IMGAUG + '.imgaug.transforms.{name})'
 
 
 class Targets(Enum):
@@ -120,23 +121,35 @@ def make_transforms_targets_links(transforms_info):
 
 
 def check_docs(filepath, image_only_transforms_links, dual_transforms_table):
-    with open(args.filepath) as f:
-        text = f.read()
-    outdated_docs = []
-    if image_only_transforms_links not in text:
-        outdated_docs.append("Pixel-level")
-    if dual_transforms_table not in text:
-        outdated_docs.append("Spatial-level")
+    with open(args.filepath, 'rb') as f:
+        text = f.read().decode('utf8')
+    outdated_docs = set()
+    image_only_lines_not_in_text = []
+    dual_lines_not_in_text = []
+    for line in image_only_transforms_links.split('\n'):
+        if line not in text:
+            outdated_docs.update(['Pixel-level'])
+            image_only_lines_not_in_text.append(line)
+    for line in dual_transforms_table.split('\n'):
+        if line not in text:
+            dual_lines_not_in_text.append(line)
+            outdated_docs.update(['Spatial-level'])
     if not outdated_docs:
         return
 
     raise ValueError(
-        "Docs for the following transform types are outdated: {outdated_docs_headers}. "
-        "Generate new docs by executing the `python tools/{py_file} make` command "
-        "and paste them to {filename}.".format(
-            outdated_docs_headers=", ".join(outdated_docs),
+        'Docs for the following transform types are outdated: {outdated_docs_headers}. '
+        'Generate new docs by executing the `python tools/{py_file} make` command '
+        'and paste them to {filename}.\n'
+        '# Image only transforms lines not in file:\n'
+        '{image_only_lines}\n'
+        '# Dual transforms lines not in file:\n'
+        '{dual_lines}'.format(
+            outdated_docs_headers=', '.join(outdated_docs),
             py_file=os.path.basename(os.path.realpath(__file__)),
             filename=os.path.basename(filepath),
+            image_only_lines='\n'.join(image_only_lines_not_in_text),
+            dual_lines='\n'.join(dual_lines_not_in_text)
         )
     )
 

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -18,7 +18,9 @@ IGNORED_CLASSES = {
 }
 
 
-READTHEDOCS_TEMPLATE_ALBU = '[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations'
+READTHEDOCS_TEMPLATE_ALBU = (
+    '[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations'
+)
 READTHEDOCS_TEMPLATE_IMGAUG = '[{name}](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations'
 TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_ALBU + '.augmentations.transforms.{name})'
 IMGAUG_TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_IMGAUG + '.imgaug.transforms.{name})'

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -123,8 +123,8 @@ def make_transforms_targets_links(transforms_info):
 
 
 def check_docs(filepath, image_only_transforms_links, dual_transforms_table):
-    with open(args.filepath, 'rb') as f:
-        text = f.read().decode('utf8')
+    with open(args.filepath, 'r', encoding='utf8') as f:
+        text = f.read()
     outdated_docs = set()
     image_only_lines_not_in_text = []
     dual_lines_not_in_text = []

--- a/tools/make_transforms_docs.py
+++ b/tools/make_transforms_docs.py
@@ -19,11 +19,11 @@ IGNORED_CLASSES = {
 
 
 READTHEDOCS_TEMPLATE_ALBU = (
-    '[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations'
+    "[{name}](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations"
 )
-READTHEDOCS_TEMPLATE_IMGAUG = '[{name}](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations'
-TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_ALBU + '.augmentations.transforms.{name})'
-IMGAUG_TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_IMGAUG + '.imgaug.transforms.{name})'
+READTHEDOCS_TEMPLATE_IMGAUG = "[{name}](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations"
+TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_ALBU + ".augmentations.transforms.{name})"
+IMGAUG_TRANSFORM_NAME_WITH_LINK_TEMPLATE = READTHEDOCS_TEMPLATE_IMGAUG + ".imgaug.transforms.{name})"
 
 
 class Targets(Enum):
@@ -123,35 +123,35 @@ def make_transforms_targets_links(transforms_info):
 
 
 def check_docs(filepath, image_only_transforms_links, dual_transforms_table):
-    with open(args.filepath, 'r', encoding='utf8') as f:
+    with open(args.filepath, "r", encoding="utf8") as f:
         text = f.read()
     outdated_docs = set()
     image_only_lines_not_in_text = []
     dual_lines_not_in_text = []
-    for line in image_only_transforms_links.split('\n'):
+    for line in image_only_transforms_links.split("\n"):
         if line not in text:
-            outdated_docs.update(['Pixel-level'])
+            outdated_docs.update(["Pixel-level"])
             image_only_lines_not_in_text.append(line)
-    for line in dual_transforms_table.split('\n'):
+    for line in dual_transforms_table.split("\n"):
         if line not in text:
             dual_lines_not_in_text.append(line)
-            outdated_docs.update(['Spatial-level'])
+            outdated_docs.update(["Spatial-level"])
     if not outdated_docs:
         return
 
     raise ValueError(
-        'Docs for the following transform types are outdated: {outdated_docs_headers}. '
-        'Generate new docs by executing the `python tools/{py_file} make` command '
-        'and paste them to {filename}.\n'
-        '# Image only transforms lines not in file:\n'
-        '{image_only_lines}\n'
-        '# Dual transforms lines not in file:\n'
-        '{dual_lines}'.format(
-            outdated_docs_headers=', '.join(outdated_docs),
+        "Docs for the following transform types are outdated: {outdated_docs_headers}. "
+        "Generate new docs by executing the `python tools/{py_file} make` command "
+        "and paste them to {filename}.\n"
+        "# Image only transforms lines not in file:\n"
+        "{image_only_lines}\n"
+        "# Dual transforms lines not in file:\n"
+        "{dual_lines}".format(
+            outdated_docs_headers=", ".join(outdated_docs),
             py_file=os.path.basename(os.path.realpath(__file__)),
             filename=os.path.basename(filepath),
-            image_only_lines='\n'.join(image_only_lines_not_in_text),
-            dual_lines='\n'.join(dual_lines_not_in_text)
+            image_only_lines="\n".join(image_only_lines_not_in_text),
+            dual_lines="\n".join(dual_lines_not_in_text),
         )
     )
 


### PR DESCRIPTION
Fixed Imgaug transforms urls.
Fixed README check for Win10 (different encoding while read text)
Now make_transforms_docs.py shows not finded lines in text

#368