### PR TITLE
Better Sphinx test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 - if [[ "$TEST_MODE" == "BLACK" ]]; then pip install black; fi
 - if [[ "$TEST_MODE" == "SPHINX" ]]; then pip install -r docs/requirements.txt; fi
 - if [[ -n "$PYTORCH_WHEEL" ]]; then pip install "$PYTORCH_WHEEL" torchvision; fi
-- if [[ "$TEST_MODE" == "DEFAULT" ]]; then pip install .[tests]; fi
+- if [[ "$TEST_MODE" == "DEFAULT" ]] || [[ "$TEST_MODE" == "SPHINX" ]]; then pip install .[tests]; fi
 - if [[ "$TEST_MODE" == "DEFAULT" ]]; then pip install "pydocstyle<4.0.0" flake8 flake8-docstrings; fi
 
 script:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ project = "albumentations"
 
 authors = "Alexander Buslaev, Alex Parinov, Vladimir Iglovikov, Evegene Khvedchenya, Mikhail Druzhinin"
 
-copyright = ("{}, {}".format(datetime.datetime.now().year, authors),)
+copyright = "{}, {}".format(datetime.datetime.now().year, authors)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx
-sphinx-autobuild
-sphinx_rtd_theme
+https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
 mock
 numpy==1.15.4
 scikit-image
-https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
+sphinx-autobuild
+sphinx<2
+sphinx_rtd_theme


### PR DESCRIPTION
- Use sphinx<2 in docs/requirements.txt (The same requirement is used by ReadTheDocs for building docs).
- Resolve building error on ReadTheDocs.
- Install all library dependencies in Travis CI while building docs.