### PR TITLE
Keypoints support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :---: | :----: | :-------: |
 | [CenterCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CenterCrop)                             | ✓     | ✓     | ✓      | ✓         |
 | [Crop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Crop)                                         | ✓     | ✓     | ✓      | ✓         |
-| [CropNonEmptyMaskIfExists](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CropNonEmptyMaskIfExists) | ✓     | ✓     |        |           |
+| [CropNonEmptyMaskIfExists](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CropNonEmptyMaskIfExists) | ✓     | ✓     | ✓      | ✓         |
 | [ElasticTransform](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ElasticTransform)                 | ✓     | ✓     |        |           |
 | [Flip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Flip)                                         | ✓     | ✓     | ✓      | ✓         |
 | [GridDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.GridDistortion)                     | ✓     | ✓     |        |           |
@@ -173,7 +173,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [OpticalDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.OpticalDistortion)               | ✓     | ✓     |        |           |
 | [PadIfNeeded](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.PadIfNeeded)                           | ✓     | ✓     | ✓      | ✓         |
 | [RandomCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCrop)                             | ✓     | ✓     | ✓      | ✓         |
-| [RandomCropNearBBox](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCropNearBBox)             | ✓     | ✓     | ✓      |           |
+| [RandomCropNearBBox](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomCropNearBBox)             | ✓     | ✓     | ✓      | ✓         |
 | [RandomGridShuffle](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomGridShuffle)               | ✓     | ✓     |        |           |
 | [RandomResizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomResizedCrop)               | ✓     | ✓     | ✓      | ✓         |
 | [RandomRotate90](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomRotate90)                     | ✓     | ✓     | ✓      | ✓         |
@@ -184,7 +184,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [Rotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Rotate)                                     | ✓     | ✓     | ✓      | ✓         |
 | [ShiftScaleRotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ShiftScaleRotate)                 | ✓     | ✓     | ✓      | ✓         |
 | [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      | ✓         |
-| [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      |           |
+| [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      | ✓         |
 | [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                         | ✓     | ✓     | ✓      | ✓         |
 
 ## Migrating from torchvision to albumentations

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | Transform                                                                                                                                                           | Image | Masks | BBoxes | Keypoints |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---: | :---: | :----: | :-------: |
 | [CenterCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CenterCrop)                             | ✓     | ✓     | ✓      | ✓         |
-| [Crop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Crop)                                         | ✓     | ✓     | ✓      |           |
+| [Crop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Crop)                                         | ✓     | ✓     | ✓      | ✓         |
 | [CropNonEmptyMaskIfExists](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.CropNonEmptyMaskIfExists) | ✓     | ✓     |        |           |
 | [ElasticTransform](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ElasticTransform)                 | ✓     | ✓     |        |           |
 | [Flip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Flip)                                         | ✓     | ✓     | ✓      | ✓         |
@@ -168,7 +168,7 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [IAAPerspective](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAPerspective)                                   | ✓     | ✓     | ✓      | ✓         |
 | [IAAPiecewiseAffine](https://albumentations.readthedocs.io/en/latest/api/imgaug.html#albumentations.imgaug.transforms.IAAPiecewiseAffine)                           | ✓     | ✓     | ✓      | ✓         |
 | [Lambda](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Lambda)                                     | ✓     | ✓     | ✓      | ✓         |
-| [LongestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.LongestMaxSize)                     | ✓     | ✓     | ✓      |           |
+| [LongestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.LongestMaxSize)                     | ✓     | ✓     | ✓      | ✓         |
 | NoOp                                                                                                                                                                | ✓     | ✓     | ✓      | ✓         |
 | [OpticalDistortion](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.OpticalDistortion)               | ✓     | ✓     |        |           |
 | [PadIfNeeded](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.PadIfNeeded)                           | ✓     | ✓     | ✓      | ✓         |
@@ -180,10 +180,10 @@ Spatial-level transforms will simultaneously change both an input image as well 
 | [RandomScale](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomScale)                           | ✓     | ✓     | ✓      | ✓         |
 | [RandomSizedBBoxSafeCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedBBoxSafeCrop)   | ✓     | ✓     | ✓      |           |
 | [RandomSizedCrop](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.RandomSizedCrop)                   | ✓     | ✓     | ✓      | ✓         |
-| [Resize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Resize)                                     | ✓     | ✓     | ✓      |           |
+| [Resize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Resize)                                     | ✓     | ✓     | ✓      | ✓         |
 | [Rotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Rotate)                                     | ✓     | ✓     | ✓      | ✓         |
 | [ShiftScaleRotate](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.ShiftScaleRotate)                 | ✓     | ✓     | ✓      | ✓         |
-| [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      |           |
+| [SmallestMaxSize](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.SmallestMaxSize)                   | ✓     | ✓     | ✓      | ✓         |
 | [Transpose](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.Transpose)                               | ✓     | ✓     | ✓      |           |
 | [VerticalFlip](https://albumentations.readthedocs.io/en/latest/api/augmentations.html#albumentations.augmentations.transforms.VerticalFlip)                         | ✓     | ✓     | ✓      | ✓         |
 

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -32,6 +32,16 @@ def clipped(func):
     return wrapped_function
 
 
+def angle_to_2pi(angle):
+    if 0 <= angle <= 2 * np.pi:
+        return angle
+
+    if angle < 0:
+        angle += abs(angle // (2 * np.pi) + 1) * 2 * np.pi
+
+    return angle % (2 * np.pi)
+
+
 def preserve_shape(func):
     """
     Preserve shape of the image
@@ -1598,3 +1608,15 @@ def swap_tiles_on_image(image, tiles):
         ]
 
     return new_image
+
+
+def keypoint_transpose(keypoint):
+    x, y, angle, scale = keypoint
+    angle = angle_to_2pi(angle)
+
+    if angle <= np.pi:
+        angle = np.pi - angle
+    else:
+        angle = 3 * np.pi - angle
+
+    return y, x, angle, scale

--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -32,12 +32,12 @@ def clipped(func):
     return wrapped_function
 
 
-def angle_to_2pi(angle):
+def angle_to_2pi_range(angle):
     if 0 <= angle <= 2 * np.pi:
         return angle
 
     if angle < 0:
-        angle += abs(angle // (2 * np.pi) + 1) * 2 * np.pi
+        angle += (abs(angle) // (2 * np.pi) + 1) * 2 * np.pi
 
     return angle % (2 * np.pi)
 
@@ -1612,7 +1612,7 @@ def swap_tiles_on_image(image, tiles):
 
 def keypoint_transpose(keypoint):
     x, y, angle, scale = keypoint
-    angle = angle_to_2pi(angle)
+    angle = angle_to_2pi_range(angle)
 
     if angle <= np.pi:
         angle = np.pi - angle

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -406,7 +406,7 @@ class Resize(DualTransform):
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
-        image, mask, bboxes
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -424,6 +424,12 @@ class Resize(DualTransform):
     def apply_to_bbox(self, bbox, **params):
         # Bounding box coordinates are scale invariant
         return bbox
+
+    def apply_to_keypoint(self, keypoint, **params):
+        height = params["rows"]
+        width = params["cols"]
+
+        return F.keypoint_scale(keypoint, self.height / height, self.width / width)
 
     def get_transform_init_args_names(self):
         return ("height", "width", "interpolation")

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -741,7 +741,7 @@ class RandomCropNearBBox(DualTransform):
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
-        image
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -771,6 +771,16 @@ class RandomCropNearBBox(DualTransform):
         h_start = y_min
         w_start = x_min
         return F.bbox_crop(bbox, y_max - y_min, x_max - x_min, h_start, w_start, **params)
+
+    def apply_to_keypoint(self, keypoint, x_min=0, x_max=0, y_min=0, y_max=0, **params):
+        return F.crop_keypoint_by_coords(
+            keypoint,
+            crop_coords=[x_min, y_min, x_max, y_max],
+            crop_height=y_max - y_min,
+            crop_width=x_max - x_min,
+            rows=params["rows"],
+            cols=params["cols"],
+        )
 
     @property
     def targets_as_params(self):

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -328,7 +328,7 @@ class LongestMaxSize(DualTransform):
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
-        image, mask, bboxes
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -345,6 +345,13 @@ class LongestMaxSize(DualTransform):
     def apply_to_bbox(self, bbox, **params):
         # Bounding box coordinates are scale invariant
         return bbox
+
+    def apply_to_keypoint(self, keypoint, **params):
+        height = params["rows"]
+        width = params["cols"]
+
+        scale = self.max_size / max([height, width])
+        return F.keypoint_scale(keypoint, scale, scale)
 
     def get_transform_init_args_names(self):
         return ("max_size", "interpolation")

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -366,7 +366,7 @@ class SmallestMaxSize(DualTransform):
         p (float): probability of applying the transform. Default: 1.
 
     Targets:
-        image, mask, bboxes
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -382,6 +382,13 @@ class SmallestMaxSize(DualTransform):
 
     def apply_to_bbox(self, bbox, **params):
         return bbox
+
+    def apply_to_keypoint(self, keypoint, **params):
+        height = params["rows"]
+        width = params["cols"]
+
+        scale = self.max_size / min([height, width])
+        return F.keypoint_scale(keypoint, scale, scale)
 
     def get_transform_init_args_names(self):
         return ("max_size", "interpolation")

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -171,7 +171,7 @@ class Crop(DualTransform):
         y_max (int): maximum lower right y coordinate.
 
     Targets:
-        image, mask, bboxes
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -189,6 +189,16 @@ class Crop(DualTransform):
 
     def apply_to_bbox(self, bbox, **params):
         return F.bbox_crop(bbox, x_min=self.x_min, y_min=self.y_min, x_max=self.x_max, y_max=self.y_max, **params)
+
+    def apply_to_keypoint(self, keypoint, **params):
+        return F.crop_keypoint_by_coords(
+            keypoint,
+            crop_coords=[self.x_min, self.y_min, self.x_max, self.y_max],
+            crop_height=self.y_max - self.y_min + 1,
+            crop_width=self.x_max - self.x_min + 1,
+            rows=params["rows"],
+            cols=params["cols"],
+        )
 
     def get_transform_init_args_names(self):
         return ("x_min", "y_min", "x_max", "y_max")

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -194,8 +194,8 @@ class Crop(DualTransform):
         return F.crop_keypoint_by_coords(
             keypoint,
             crop_coords=[self.x_min, self.y_min, self.x_max, self.y_max],
-            crop_height=self.y_max - self.y_min + 1,
-            crop_width=self.x_max - self.x_min + 1,
+            crop_height=self.y_max - self.y_min,
+            crop_width=self.x_max - self.x_min,
             rows=params["rows"],
             cols=params["cols"],
         )
@@ -1014,7 +1014,7 @@ class CropNonEmptyMaskIfExists(DualTransform):
         p (float): probability of applying the transform. Default: 1.0.
 
     Targets:
-        image, mask
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -1035,6 +1035,21 @@ class CropNonEmptyMaskIfExists(DualTransform):
 
     def apply(self, img, x_min=0, x_max=0, y_min=0, y_max=0, **params):
         return F.crop(img, x_min, y_min, x_max, y_max)
+
+    def apply_to_bbox(self, bbox, x_min=0, x_max=0, y_min=0, y_max=0, **params):
+        return F.bbox_crop(
+            bbox, x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, rows=params["rows"], cols=params["cols"]
+        )
+
+    def apply_to_keypoint(self, keypoint, x_min=0, x_max=0, y_min=0, y_max=0, **params):
+        return F.crop_keypoint_by_coords(
+            keypoint,
+            crop_coords=[x_min, y_min, x_max, y_max],
+            crop_height=y_max - y_min,
+            crop_width=x_max - x_min,
+            rows=params["rows"],
+            cols=params["cols"],
+        )
 
     @property
     def targets_as_params(self):

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -303,7 +303,7 @@ class Transpose(DualTransform):
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
-        image, mask, bboxes
+        image, mask, bboxes, keypoints
 
     Image types:
         uint8, float32
@@ -314,6 +314,10 @@ class Transpose(DualTransform):
 
     def apply_to_bbox(self, bbox, **params):
         return F.bbox_transpose(bbox, 0, **params)
+
+    def apply_to_keypoint(self, keypoint, **params):
+        x, y, a, s = keypoint
+        return [y, x, a, s]
 
     def get_transform_init_args_names(self):
         return ()

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -316,8 +316,7 @@ class Transpose(DualTransform):
         return F.bbox_transpose(bbox, 0, **params)
 
     def apply_to_keypoint(self, keypoint, **params):
-        x, y, a, s = keypoint
-        return [y, x, a, s]
+        return F.keypoint_transpose(keypoint)
 
     def get_transform_init_args_names(self):
         return ()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -424,3 +424,20 @@ def test_crop_keypoints():
     aug = A.Crop(50, 50, 100, 100, p=1)
     result = aug(image=image, keypoints=keypoints)
     assert result["keypoints"] == [[0, 0, 0, 0]]
+
+
+def test_longest_max_size_keypoints():
+    img = np.random.randint(0, 256, [10, 10], np.uint8)
+    keypoints = [[9, 5, 0, 0]]
+
+    aug = A.LongestMaxSize(max_size=100, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[90, 50, 0, 0]]
+
+    aug = A.LongestMaxSize(max_size=5, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[4.5, 2.5, 0, 0]]
+
+    aug = A.LongestMaxSize(max_size=10, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[9, 5, 0, 0]]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -458,3 +458,16 @@ def test_smallest_max_size_keypoints():
     aug = A.SmallestMaxSize(max_size=10, p=1)
     result = aug(image=img, keypoints=keypoints)
     assert result["keypoints"] == [[9, 5, 0, 0]]
+
+
+def test_resize_keypoints():
+    img = np.random.randint(0, 256, [50, 10], np.uint8)
+    keypoints = [[9, 5, 0, 0]]
+
+    aug = A.Resize(height=100, width=5, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[18, 2.5, 0, 0]]
+
+    aug = A.Resize(height=50, width=10, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[9, 5, 0, 0]]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -411,3 +411,16 @@ def test_downscale(interpolation):
         transformed = aug(image=img)["image"]
         func_applied = F.downscale(img, scale=0.5, interpolation=interpolation)
         np.testing.assert_almost_equal(transformed, func_applied)
+
+
+def test_crop_keypoints():
+    image = np.random.randint(0, 256, (100, 100), np.uint8)
+    keypoints = [[50, 50, 0, 0]]
+
+    aug = A.Crop(0, 0, 80, 80, p=1)
+    result = aug(image=image, keypoints=keypoints)
+    assert result["keypoints"] == keypoints
+
+    aug = A.Crop(50, 50, 100, 100, p=1)
+    result = aug(image=image, keypoints=keypoints)
+    assert result["keypoints"] == [[0, 0, 0, 0]]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -427,17 +427,34 @@ def test_crop_keypoints():
 
 
 def test_longest_max_size_keypoints():
-    img = np.random.randint(0, 256, [10, 10], np.uint8)
+    img = np.random.randint(0, 256, [50, 10], np.uint8)
     keypoints = [[9, 5, 0, 0]]
 
     aug = A.LongestMaxSize(max_size=100, p=1)
     result = aug(image=img, keypoints=keypoints)
-    assert result["keypoints"] == [[90, 50, 0, 0]]
+    assert result["keypoints"] == [[18, 10, 0, 0]]
 
     aug = A.LongestMaxSize(max_size=5, p=1)
     result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[0.9, 0.5, 0, 0]]
+
+    aug = A.LongestMaxSize(max_size=50, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[9, 5, 0, 0]]
+
+
+def test_smallest_max_size_keypoints():
+    img = np.random.randint(0, 256, [50, 10], np.uint8)
+    keypoints = [[9, 5, 0, 0]]
+
+    aug = A.SmallestMaxSize(max_size=100, p=1)
+    result = aug(image=img, keypoints=keypoints)
+    assert result["keypoints"] == [[90, 50, 0, 0]]
+
+    aug = A.SmallestMaxSize(max_size=5, p=1)
+    result = aug(image=img, keypoints=keypoints)
     assert result["keypoints"] == [[4.5, 2.5, 0, 0]]
 
-    aug = A.LongestMaxSize(max_size=10, p=1)
+    aug = A.SmallestMaxSize(max_size=10, p=1)
     result = aug(image=img, keypoints=keypoints)
     assert result["keypoints"] == [[9, 5, 0, 0]]


### PR DESCRIPTION
Added keypoints support to next transforms:
- Crop
- CropNonEmptyMaskIfExists
- LongestMaxSize
- RandomCropNearBBox
- Resize
- SmallestMaxSize
- Transpose

#184 