### PR TITLE
keypoints resize was fixed

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -431,8 +431,9 @@ class Resize(DualTransform):
     def apply_to_keypoint(self, keypoint, **params):
         height = params["rows"]
         width = params["cols"]
-
-        return F.keypoint_scale(keypoint, self.height / height, self.width / width)
+        scale_x = self.width / width
+        scale_y = self.height / height
+        return F.keypoint_scale(keypoint, scale_x, scale_y)
 
     def get_transform_init_args_names(self):
         return ("height", "width", "interpolation")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -466,7 +466,7 @@ def test_resize_keypoints():
 
     aug = A.Resize(height=100, width=5, p=1)
     result = aug(image=img, keypoints=keypoints)
-    assert result["keypoints"] == [[18, 2.5, 0, 0]]
+    assert result["keypoints"] == [[4.5, 10, 0, 0]]
 
     aug = A.Resize(height=50, width=10, p=1)
     result = aug(image=img, keypoints=keypoints)


### PR DESCRIPTION
Resize augmentations worked with keypoints in an incorrect way. The keypoints test for this augmentation also was broken. Scales inside `apply_to_keypoints` function were swapped. 