### PR TITLE
Fix max_holes behavior in CoarseDropout

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1550,7 +1550,7 @@ class CoarseDropout(ImageOnlyTransform):
         height, width = img.shape[:2]
 
         holes = []
-        for _n in range(random.randint(self.min_holes, self.max_holes + 1)):
+        for _n in range(random.randint(self.min_holes, self.max_holes)):
             hole_height = random.randint(self.min_height, self.max_height + 1)
             hole_width = random.randint(self.min_width, self.max_width + 1)
 

--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -1551,8 +1551,8 @@ class CoarseDropout(ImageOnlyTransform):
 
         holes = []
         for _n in range(random.randint(self.min_holes, self.max_holes)):
-            hole_height = random.randint(self.min_height, self.max_height + 1)
-            hole_width = random.randint(self.min_width, self.max_width + 1)
+            hole_height = random.randint(self.min_height, self.max_height)
+            hole_width = random.randint(self.min_width, self.max_width)
 
             y1 = random.randint(0, height - hole_height)
             x1 = random.randint(0, width - hole_width)


### PR DESCRIPTION
Current implementation of CoarseDropout may produce `max_holes + 1` holes. I modified the logic to determine the number of holes.
issue: #436

Could you check the changes and consider to merge it?
Thank you :)
