### PR TITLE
Minor fix on Blur parameter: np.int64 -> int

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -2386,7 +2386,7 @@ class Blur(ImageOnlyTransform):
         return F.blur(image, ksize)
 
     def get_params(self):
-        return {"ksize": random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2))}
+        return {"ksize": int(random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2)))}
 
     def get_transform_init_args_names(self):
         return ("blur_limit",)


### PR DESCRIPTION
Hi, 
I propose this minor change such that replay blur parameters can be serialized with json. Otherwise, 
```
Object of type int64 is not JSON serializable
```