### PR TITLE
Pin Black version in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
 install:
 - pip install --upgrade pip pytest
 - if [[ "$TEST_MODE" == "DOCS" ]]; then pip install .; fi
-- if [[ "$TEST_MODE" == "BLACK" ]]; then pip install black; fi
+- if [[ "$TEST_MODE" == "BLACK" ]]; then pip install black==19.3b0; fi
 - if [[ "$TEST_MODE" == "SPHINX" ]]; then pip install -r docs/requirements.txt; fi
 - if [[ -n "$PYTORCH_WHEEL" ]]; then pip install "$PYTORCH_WHEEL" torchvision; fi
 - if [[ "$TEST_MODE" == "DEFAULT" ]] || [[ "$TEST_MODE" == "SPHINX" ]]; then pip install .[tests]; fi


### PR DESCRIPTION
Use black==19.3b0 in Travis CI. It is the same version that we use in the pre-commit hook.