### PR TITLE
sovle KeyError

### DIFF
--- a/albumentations/augmentations/functional.py
+++ b/albumentations/augmentations/functional.py
@@ -1262,8 +1262,8 @@ def gauss_noise(image, gauss):
 
 @clipped
 def _brightness_contrast_adjust_non_uint(img, alpha=1, beta=0, beta_by_max=False):
-    dtype = img.dtype
     img = img.astype("float32")
+    dtype = img.dtype
 
     if alpha != 1:
         img *= alpha


### PR DESCRIPTION
if image's type is float64 may lead to keyError  bug.
```return clip(func(img, *args, **kwargs), dtype, maxval)
  File "....../site-packages/albumentations/augmentations/functional.py", line 1271, in _brightness_contrast_adjust_non_uint
    max_value = MAX_VALUES_BY_DTYPE[dtype]
KeyError: dtype('float64')
```