### PR TITLE
Shrink source distribution size

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ graft benchmark
 graft tests
 graft docs
 prune docs/_build
+global-exclude docs/augs_overview/*/images/*.jpg
 
 global-exclude *.py[co] .DS_Store

--- a/albumentations/__init__.py
+++ b/albumentations/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 from .core.composition import *
 from .core.transforms_interface import *


### PR DESCRIPTION
Do not include images from augs_overview into the source distribution. Reduce the size of the source distribution from 3 MB to 100 KB.